### PR TITLE
Make form layouts responsive

### DIFF
--- a/src/components/FormContainer.css
+++ b/src/components/FormContainer.css
@@ -1,7 +1,7 @@
 .form-container {
-  max-width: 320px;
+  width: min(100% - 2rem, 360px);
   margin: 20px auto auto;
-  padding: 1.5rem 2rem; /* padding vertical y horizontal igual */
+  padding: clamp(1rem, 4vw, 1.5rem) clamp(1.25rem, 5vw, 2rem);
   border: 1px solid #ddd;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -5,9 +5,9 @@
 }
 
 .divSecundario {
-  max-width: 300px;
+  width: min(100% - 2rem, 360px);
   margin: 0 auto;
-  padding: 2rem;
+  padding: clamp(1.25rem, 5vw, 2rem);
   border-radius: 8px;
 }
 

--- a/src/pages/SignUp.css
+++ b/src/pages/SignUp.css
@@ -5,9 +5,9 @@
 }
 
 .divSecundario {
-  max-width: 300px;
+  width: min(100% - 2rem, 360px);
   margin: 0 auto;
-  padding: 2rem;
+  padding: clamp(1.25rem, 5vw, 2rem);
   border-radius: 8px;
 }
 


### PR DESCRIPTION
## Summary
- add a global border-box rule so padding and borders do not increase element width
- switch form container widths and paddings to use fluid measurements and clamp
- align login and signup secondary container sizing with the same responsive logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cccbcd9ae0832f9fc9e60d27bd2948