### PR TITLE
Ajusta estilos de etiquetas de formularios

### DIFF
--- a/src/components/Input.css
+++ b/src/components/Input.css
@@ -4,7 +4,10 @@
 
 .input-label {
   display: block;
+  width: 100%;
   margin-bottom: 4px;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .input-field {

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -13,16 +13,11 @@
 
 
 
-.label-login{
-
-width: 299px;
-height: 22px;
-
-font-family: 'Roboto';
-font-style: normal;
-font-weight: 400;
-font-size: 16px;
-line-height: 140%;
-color: #7F0168;
-
+.label-login {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 140%;
+  color: #7F0168;
 }

--- a/src/pages/SignUp.css
+++ b/src/pages/SignUp.css
@@ -11,17 +11,13 @@
   border-radius: 8px;
 }
 
-.label-signup{
-
-width: 299px;
-height: 22px;
-
-font-family: 'Roboto';
-font-style: normal;
-font-weight: 400;
-font-size: 16px;
-line-height: 140%;
-color: #FF5841;
+.label-signup {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 140%;
+  color: #FF5841;
 }
 
 .mensajeExito {


### PR DESCRIPTION
## Summary
- remove explicit width and height from the login and signup label styles while keeping their typography and colors
- update the shared input label styles so form labels span the available width and wrap long text to avoid horizontal scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd098cac0832fb301cac7f44ac08e