### PR TITLE
Rediseñar TarjetaViaje con nuevo layout estilo card

### DIFF
--- a/src/components/TarjetaViaje.css
+++ b/src/components/TarjetaViaje.css
@@ -1,60 +1,125 @@
-.tarjeta-trayecto {
+.tarjeta-viaje {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: #f7f0fa;
-  border-radius: 12px;
-  padding: 12px 16px;
-  margin-bottom: 12px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: 0 12px 30px rgba(31, 24, 54, 0.08);
+  border: 1px solid rgba(197, 54, 120, 0.08);
 }
 
-.trayecto-izq {
+.tarjeta-viaje__contenido {
+  display: flex;
+  gap: 16px;
+}
+
+.tarjeta-viaje__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #f1e4fb, #f9d9eb);
+  color: #a12a63;
+  font-weight: 600;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.tarjeta-viaje__texto {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tarjeta-viaje__nombre {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #1f1f1f;
+}
+
+.tarjeta-viaje__fila-principal {
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
-.avatar-trayecto {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: #f4e2ea;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-weight: bold;
-  color: #C53678;
-}
-
-.trayecto-textos {
-  display: flex;
-  flex-direction: column;
-}
-
-.trayecto-titulo {
+.tarjeta-viaje__destino {
+  font-size: 1.05rem;
   font-weight: 600;
-  font-size: 0.95rem;
+  color: #27272a;
 }
 
-.trayecto-detalle {
-  font-size: 0.85rem;
-  color: #555;
+.tarjeta-viaje__precio {
+  background: rgba(197, 54, 120, 0.12);
+  color: #a12a63;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.9rem;
+  white-space: nowrap;
 }
 
-.trayecto-acciones {
+.tarjeta-viaje__fecha {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.tarjeta-viaje__acciones {
   display: flex;
-  gap: 8px;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
-.icono-btn {
-  border: none;
-  background: transparent;
-  font-size: 1.2rem;
+.tarjeta-viaje__btn {
+  flex: 1 1 140px;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  padding: 10px 18px;
+  font-weight: 600;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    color 0.2s ease;
 }
 
-.icono-primario {
-  color: #C53678;
-  font-weight: bold;
+.tarjeta-viaje__btn--primario {
+  background-color: #c53678;
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(197, 54, 120, 0.25);
+}
+
+.tarjeta-viaje__btn--primario:hover {
+  background-color: #a12a63;
+  transform: translateY(-1px);
+}
+
+.tarjeta-viaje__btn--secundario {
+  background-color: #ffffff;
+  color: #c53678;
+  border-color: rgba(197, 54, 120, 0.4);
+}
+
+.tarjeta-viaje__btn--secundario:hover {
+  background-color: rgba(197, 54, 120, 0.08);
+  transform: translateY(-1px);
+}
+
+@media (max-width: 480px) {
+  .tarjeta-viaje {
+    padding: 16px;
+  }
+
+  .tarjeta-viaje__precio {
+    width: 100%;
+    text-align: center;
+  }
+
+  .tarjeta-viaje__btn {
+    flex: 1 1 100%;
+  }
 }

--- a/src/components/TarjetaViaje.jsx
+++ b/src/components/TarjetaViaje.jsx
@@ -1,36 +1,60 @@
 // src/components/TarjetaViaje.jsx
 import "./TarjetaViaje.css";
 
-function TarjetaViaje({ sigla, titulo, detalle, onAgregar, onOpciones }) {
+function TarjetaViaje({
+  sigla,
+  nombre,
+  destino,
+  fecha,
+  precio,
+  onSumarse,
+  onVerMas,
+  titulo,
+  detalle,
+  onAgregar,
+  onOpciones,
+}) {
+  const inicial = (sigla || nombre?.[0] || titulo?.[0] || destino?.[0] || "?").toUpperCase();
+  const nombreMostrar = nombre || titulo || destino || "Conductor";
+  const destinoMostrar = destino || titulo || nombre || "Punto de encuentro";
+  const fechaMostrar = fecha || detalle || "";
+  const precioMostrar = precio || "Consultar";
+  const handleSumarse = onSumarse || onAgregar;
+  const handleVerMas = onVerMas || onOpciones;
+
   return (
-    <div className="tarjeta-trayecto">
-      <div className="trayecto-izq">
-        <div className="avatar-trayecto">{sigla}</div>
-        <div className="trayecto-textos">
-          <div className="trayecto-titulo">{titulo}</div>
-          <div className="trayecto-detalle">{detalle}</div>
+    <article className="tarjeta-viaje">
+      <div className="tarjeta-viaje__contenido">
+        <div className="tarjeta-viaje__avatar" aria-hidden="true">
+          {inicial}
+        </div>
+        <div className="tarjeta-viaje__texto">
+          <span className="tarjeta-viaje__nombre">{nombreMostrar}</span>
+          <div className="tarjeta-viaje__fila-principal">
+            <span className="tarjeta-viaje__destino">{destinoMostrar}</span>
+            <span className="tarjeta-viaje__precio">{precioMostrar}</span>
+          </div>
+          {fechaMostrar && <span className="tarjeta-viaje__fecha">{fechaMostrar}</span>}
         </div>
       </div>
 
-      <div className="trayecto-acciones">
+      <div className="tarjeta-viaje__acciones">
         <button
           type="button"
-          className="icono-btn"
-          aria-label="Más opciones"
-          onClick={onOpciones}
+          className="tarjeta-viaje__btn tarjeta-viaje__btn--primario"
+          onClick={() => handleSumarse?.()}
         >
-          ⋮
+          Sumarse
         </button>
         <button
           type="button"
-          className="icono-btn icono-primario"
-          aria-label="Agregar trayecto"
-          onClick={onAgregar}
+          className="tarjeta-viaje__btn tarjeta-viaje__btn--secundario"
+          onClick={() => handleVerMas?.()}
         >
-          +
+          Ver más
         </button>
       </div>
-    </div>
+    </article>
   );
 }
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,7 +6,6 @@ import Button from "../components/Button";
 import TarjetaViaje from "../components/TarjetaViaje";
 
 function Home() {
-  
   let usuario = null;
   const usuarioGuardado = localStorage.getItem("usuario");
   if (usuarioGuardado) {
@@ -19,7 +18,7 @@ function Home() {
   }
 
   // === nuevo estado UI Home ===
-const nombreBarrio = usuario?.barrio?.nombre || "Mi barrio";
+  const nombreBarrio = usuario?.barrio?.nombre || "Mi barrio";
   const [modoViaje, setModoViaje] = useState("hacia"); // "hacia" | "desde"
   const [lugar, setLugar] = useState(null); // Google Place
 
@@ -38,18 +37,41 @@ const nombreBarrio = usuario?.barrio?.nombre || "Mi barrio";
     setMostrarTrayectos(true);
   };
 
-  return (
-    
-      <FormContainer>
+  const trayectosEjemplo = [
+    {
+      id: 1,
+      nombre: "Martín",
+      sigla: "M",
+      destino: "Plaza Italia",
+      fecha: "25 de abr. 14:00",
+      precio: "$2000 / asiento",
+    },
+    {
+      id: 2,
+      nombre: "Ana",
+      sigla: "A",
+      destino: "USAL Pilar",
+      fecha: "Lunes a Viernes · 08:00",
+      precio: "$1800 / asiento",
+    },
+    {
+      id: 3,
+      nombre: "Valentina",
+      sigla: "V",
+      destino: "Escobar centro",
+      fecha: "Martes · 16:00",
+      precio: "$1500 / asiento",
+    },
+  ];
 
+  return (
+    <FormContainer>
       <LoadScript
         googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
         libraries={["places"]}
       >
-
-      <form onSubmit={handleSubmit} className="form-buscar">
-
-        {/* Buscador de direcciones*/}
+        <form onSubmit={handleSubmit} className="form-buscar">
+          {/* Buscador de direcciones*/}
           <div className="campo-direccion">
             {modoViaje === "hacia" ? (
               <AutocompleteInput
@@ -68,62 +90,54 @@ const nombreBarrio = usuario?.barrio?.nombre || "Mi barrio";
             )}
           </div>
 
-        {/* Contenedor con las mismas clases que en Publicar.jsx */}
-        <div className="input-group" style={{ marginTop: 8 }}>
-          {/* Selector de dirección (reutiliza .radio-viaje) */}
-          <div className="radio-viaje">
-            <label>
-              <input
-                type="radio"
-                value="hacia"
-                checked={modoViaje === "hacia"}
-                onChange={() => setModoViaje("hacia")}
-              />
-              Viajo hacia {nombreBarrio}
-            </label>
-            <label>
-              <input
-                type="radio"
-                value="desde"
-                checked={modoViaje === "desde"}
-                onChange={() => setModoViaje("desde")}
-              />
-              Viajo desde {nombreBarrio}
-            </label>
+          {/* Contenedor con las mismas clases que en Publicar.jsx */}
+          <div className="input-group" style={{ marginTop: 8 }}>
+            {/* Selector de dirección (reutiliza .radio-viaje) */}
+            <div className="radio-viaje">
+              <label>
+                <input
+                  type="radio"
+                  value="hacia"
+                  checked={modoViaje === "hacia"}
+                  onChange={() => setModoViaje("hacia")}
+                />
+                Viajo hacia {nombreBarrio}
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  value="desde"
+                  checked={modoViaje === "desde"}
+                  onChange={() => setModoViaje("desde")}
+                />
+                Viajo desde {nombreBarrio}
+              </label>
+            </div>
           </div>
-          
-        </div>
 
-        <Button type="submit" className="botonPrimario">Buscar</Button>
-      
-      </form>
-
+          <Button type="submit" className="botonPrimario">Buscar</Button>
+        </form>
       </LoadScript>
 
       {mostrarTrayectos && (
         <section ref={resultadosRef} className="seccion-trayectos">
           <h3 className="seccion-titulo">Trayectos disponibles</h3>
 
-          {[
-            { id: 1, sigla: "A", titulo: "USAL Pilar", detalle: "Lunes a Viernes 8:00 hrs" },
-            { id: 2, sigla: "V", titulo: "Escobar centro", detalle: "Martes 16:00 hrs" },
-            { id: 3, sigla: "F", titulo: "Plaza Italia", detalle: "Lunes y Miércoles 8:00 hrs" },
-          ].map((t) => (
+          {trayectosEjemplo.map((t) => (
             <TarjetaViaje
               key={t.id}
               sigla={t.sigla}
-              titulo={t.titulo}
-              detalle={t.detalle}
-              onAgregar={() => console.log("Agregar", t)}
-              onOpciones={() => console.log("Opciones de", t)}
+              nombre={t.nombre}
+              destino={t.destino}
+              fecha={t.fecha}
+              precio={t.precio}
+              onSumarse={() => console.log("Sumarse", t)}
+              onVerMas={() => console.log("Ver más de", t)}
             />
           ))}
         </section>
-        )}
-
-      </FormContainer>
-
-      
+      )}
+    </FormContainer>
   );
 }
 


### PR DESCRIPTION
## Summary
- rediseñé el componente `TarjetaViaje` para que admita el nuevo layout tipo card y compatibilidad con las props anteriores
- actualicé los estilos de la tarjeta para recrear el diseño con avatar circular, precio destacado y botones primario/secundario
- ajusté la pantalla de inicio para poblar trayectos de ejemplo con datos acordes al nuevo diseño y usar los nuevos callbacks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ae7db4bc832f90ccae0fea98f9f6