### PR TITLE
Make Home search form collapsible

### DIFF
--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -1,3 +1,76 @@
+.buscador-colapsable {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.buscador-resumen {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  background-color: #fff;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.buscador-resumen:hover,
+.buscador-resumen:focus-visible {
+  border-color: #c53678;
+  box-shadow: 0 0 0 3px rgba(197, 54, 120, 0.15);
+  outline: none;
+}
+
+.buscador-resumen__icono {
+  color: #c53678;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.buscador-placeholder {
+  flex: 1;
+  color: #8c8c8c;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.buscador-placeholder--activo {
+  color: #1f1f1f;
+}
+
+.buscador-icon {
+  transition: transform 0.2s ease;
+  color: #666;
+  flex-shrink: 0;
+}
+
+.buscador-icon--abierto {
+  transform: rotate(180deg);
+}
+
+.buscador-contenido {
+  animation: fadeDown 0.2s ease;
+}
+
+@keyframes fadeDown {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .campo-direccion {
   margin-top: 1rem;
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import AutocompleteInput from "../components/AutoCompleteInput";
 import { LoadScript } from "@react-google-maps/api";
 import FormContainer from "../components/FormContainer";
 import Button from "../components/Button";
 import TarjetaViaje from "../components/TarjetaViaje";
+import { FaSearch, FaChevronDown } from "react-icons/fa";
+import "./Home.css";
 
 function Home() {
   let usuario = null;
@@ -21,9 +23,11 @@ function Home() {
   const nombreBarrio = usuario?.barrio?.nombre || "Mi barrio";
   const [modoViaje, setModoViaje] = useState("hacia"); // "hacia" | "desde"
   const [lugar, setLugar] = useState(null); // Google Place
+  const [buscadorExpandido, setBuscadorExpandido] = useState(false);
 
   const [mostrarTrayectos, setMostrarTrayectos] = useState(false);
   const resultadosRef = useRef(null);
+  const buscadorContentId = useId();
 
   useEffect(() => {
     if (mostrarTrayectos && resultadosRef.current) {
@@ -35,6 +39,10 @@ function Home() {
     e.preventDefault();
     // activamos los trayectos de ejemplo
     setMostrarTrayectos(true);
+  };
+
+  const toggleBuscador = () => {
+    setBuscadorExpandido((prev) => !prev);
   };
 
   const trayectosEjemplo = [
@@ -66,58 +74,89 @@ function Home() {
 
   return (
     <FormContainer>
-      <LoadScript
-        googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
-        libraries={["places"]}
-      >
-        <form onSubmit={handleSubmit} className="form-buscar">
-          {/* Buscador de direcciones*/}
-          <div className="campo-direccion">
-            {modoViaje === "hacia" ? (
-              <AutocompleteInput
-                label="Desde"
-                placeholder="Ingrese dirección de origen"
-                value={lugar?.formatted_address || ""}
-                onPlaceSelected={(place) => setLugar(place)}
-              />
-            ) : (
-              <AutocompleteInput
-                label="Hacia"
-                placeholder="Ingrese dirección de destino"
-                value={lugar?.formatted_address || ""}
-                onPlaceSelected={(place) => setLugar(place)}
-              />
-            )}
-          </div>
+      <div className="buscador-colapsable">
+        <button
+          type="button"
+          className="buscador-resumen"
+          onClick={toggleBuscador}
+          aria-expanded={buscadorExpandido}
+          aria-controls={buscadorContentId}
+        >
+          <FaSearch className="buscador-resumen__icono" aria-hidden="true" />
+          <span
+            className={`buscador-placeholder${
+              lugar ? " buscador-placeholder--activo" : ""
+            }`}
+          >
+            {lugar?.formatted_address || "Buscar trayectos"}
+          </span>
+          <FaChevronDown
+            className={`buscador-icon${
+              buscadorExpandido ? " buscador-icon--abierto" : ""
+            }`}
+            aria-hidden="true"
+          />
+        </button>
 
-          {/* Contenedor con las mismas clases que en Publicar.jsx */}
-          <div className="input-group" style={{ marginTop: 8 }}>
-            {/* Selector de dirección (reutiliza .radio-viaje) */}
-            <div className="radio-viaje">
-              <label>
-                <input
-                  type="radio"
-                  value="hacia"
-                  checked={modoViaje === "hacia"}
-                  onChange={() => setModoViaje("hacia")}
-                />
-                Viajo hacia {nombreBarrio}
-              </label>
-              <label>
-                <input
-                  type="radio"
-                  value="desde"
-                  checked={modoViaje === "desde"}
-                  onChange={() => setModoViaje("desde")}
-                />
-                Viajo desde {nombreBarrio}
-              </label>
-            </div>
-          </div>
+        {buscadorExpandido && (
+          <div id={buscadorContentId} className="buscador-contenido">
+            <LoadScript
+              googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
+              libraries={["places"]}
+            >
+              <form onSubmit={handleSubmit} className="form-buscar">
+                {/* Buscador de direcciones*/}
+                <div className="campo-direccion">
+                  {modoViaje === "hacia" ? (
+                    <AutocompleteInput
+                      label="Desde"
+                      placeholder="Ingrese dirección de origen"
+                      value={lugar?.formatted_address || ""}
+                      onPlaceSelected={(place) => setLugar(place)}
+                    />
+                  ) : (
+                    <AutocompleteInput
+                      label="Hacia"
+                      placeholder="Ingrese dirección de destino"
+                      value={lugar?.formatted_address || ""}
+                      onPlaceSelected={(place) => setLugar(place)}
+                    />
+                  )}
+                </div>
 
-          <Button type="submit" className="botonPrimario">Buscar</Button>
-        </form>
-      </LoadScript>
+                {/* Contenedor con las mismas clases que en Publicar.jsx */}
+                <div className="input-group" style={{ marginTop: 8 }}>
+                  {/* Selector de dirección (reutiliza .radio-viaje) */}
+                  <div className="radio-viaje">
+                    <label>
+                      <input
+                        type="radio"
+                        value="hacia"
+                        checked={modoViaje === "hacia"}
+                        onChange={() => setModoViaje("hacia")}
+                      />
+                      Viajo hacia {nombreBarrio}
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        value="desde"
+                        checked={modoViaje === "desde"}
+                        onChange={() => setModoViaje("desde")}
+                      />
+                      Viajo desde {nombreBarrio}
+                    </label>
+                  </div>
+                </div>
+
+                <Button type="submit" className="botonPrimario">
+                  Buscar
+                </Button>
+              </form>
+            </LoadScript>
+          </div>
+        )}
+      </div>
 
       {mostrarTrayectos && (
         <section ref={resultadosRef} className="seccion-trayectos">


### PR DESCRIPTION
## Summary
- add a collapsible wrapper so the Home search shows a compact summary by default
- toggle the form content when expanding while keeping the current filters and address
- style the collapsed state to look like a search bar and animate the expanded content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2c241a9fc832fb6762b3cf44b7d23