### PR TITLE
Refactor buscador home con nuevos estilos

### DIFF
--- a/src/components/AutoCompleteInput.jsx
+++ b/src/components/AutoCompleteInput.jsx
@@ -4,12 +4,18 @@ import "./Input.css";
 
 //onPlaceSelected funcion que se llama cuando el usuario elije un lugar
 
-const AutocompleteInput = ({ value, onPlaceSelected, placeholder, label }) => {
+const AutocompleteInput = ({
+  value,
+  onPlaceSelected,
+  placeholder,
+  label,
+  containerClassName = "",
+  inputClassName = "",
+  inputProps = {},
+}) => {
   const autocompleteRef = useRef(null);
 
-  {/* Se ejecuta cuando el usuario elige una sugerencia
-    getPlace devuelve el lugar
-   */}
+  // Se ejecuta cuando el usuario elige una sugerencia; getPlace devuelve el lugar seleccionado
   const handlePlaceChanged = () => {
     const place = autocompleteRef.current.getPlace();
     if (place && place.formatted_address) {
@@ -18,9 +24,11 @@ const AutocompleteInput = ({ value, onPlaceSelected, placeholder, label }) => {
   };
 
   return (
-    
-    <div className="input-group">
-      
+    <div
+      className={`input-group${
+        containerClassName ? ` ${containerClassName}` : ""
+      }`}
+    >
       {label && <label className="input-label">{label}</label>}
       <Autocomplete
         onLoad={(autocomplete) => (autocompleteRef.current = autocomplete)}
@@ -30,8 +38,8 @@ const AutocompleteInput = ({ value, onPlaceSelected, placeholder, label }) => {
           type="text"
           placeholder={placeholder}
           defaultValue={value}
-          className="input-field"
-          
+          className={`input-field ${inputClassName}`.trim()}
+          {...inputProps}
         />
       </Autocomplete>
     </div>

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -14,15 +14,11 @@
   border: 1px solid #ddd;
   border-radius: 12px;
   background-color: #fff;
-  cursor: pointer;
-  text-align: left;
-  font: inherit;
-  color: inherit;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.buscador-resumen:hover,
-.buscador-resumen:focus-visible {
+.buscador-resumen:focus-within,
+.buscador-resumen--abierto {
   border-color: #c53678;
   box-shadow: 0 0 0 3px rgba(197, 54, 120, 0.15);
   outline: none;
@@ -32,18 +28,6 @@
   color: #c53678;
   font-size: 1rem;
   flex-shrink: 0;
-}
-
-.buscador-placeholder {
-  flex: 1;
-  color: #8c8c8c;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.buscador-placeholder--activo {
-  color: #1f1f1f;
 }
 
 .buscador-icon {
@@ -58,6 +42,36 @@
 
 .buscador-contenido {
   animation: fadeDown 0.2s ease;
+}
+
+.buscador-resumen__input-group {
+  flex: 1;
+  margin: 0;
+  min-width: 0;
+}
+
+.buscador-resumen__input {
+  border: none;
+  background-color: transparent;
+  padding: 0;
+  margin-bottom: 0;
+  box-shadow: none;
+}
+
+.buscador-toggle {
+  background: transparent;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  cursor: pointer;
+}
+
+.buscador-toggle:focus-visible {
+  outline: 2px solid #c53678;
+  outline-offset: 2px;
 }
 
 @keyframes fadeDown {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -74,59 +74,51 @@ function Home() {
 
   return (
     <FormContainer>
-      <div className="buscador-colapsable">
-        <button
-          type="button"
-          className="buscador-resumen"
-          onClick={toggleBuscador}
-          aria-expanded={buscadorExpandido}
-          aria-controls={buscadorContentId}
-        >
-          <FaSearch className="buscador-resumen__icono" aria-hidden="true" />
-          <span
-            className={`buscador-placeholder${
-              lugar ? " buscador-placeholder--activo" : ""
-            }`}
-          >
-            {lugar?.formatted_address || "Buscar trayectos"}
-          </span>
-          <FaChevronDown
-            className={`buscador-icon${
-              buscadorExpandido ? " buscador-icon--abierto" : ""
-            }`}
-            aria-hidden="true"
-          />
-        </button>
-
-        {buscadorExpandido && (
-          <div id={buscadorContentId} className="buscador-contenido">
-            <LoadScript
-              googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
-              libraries={["places"]}
+      <LoadScript
+        googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}
+        libraries={["places"]}
+      >
+        <form onSubmit={handleSubmit} className="form-buscar">
+          <div className="buscador-colapsable">
+            <div
+              className={`buscador-resumen${
+                buscadorExpandido ? " buscador-resumen--abierto" : ""
+              }`}
             >
-              <form onSubmit={handleSubmit} className="form-buscar">
-                {/* Buscador de direcciones*/}
-                <div className="campo-direccion">
-                  {modoViaje === "hacia" ? (
-                    <AutocompleteInput
-                      label="Desde"
-                      placeholder="Ingrese dirección de origen"
-                      value={lugar?.formatted_address || ""}
-                      onPlaceSelected={(place) => setLugar(place)}
-                    />
-                  ) : (
-                    <AutocompleteInput
-                      label="Hacia"
-                      placeholder="Ingrese dirección de destino"
-                      value={lugar?.formatted_address || ""}
-                      onPlaceSelected={(place) => setLugar(place)}
-                    />
-                  )}
-                </div>
+              <FaSearch className="buscador-resumen__icono" aria-hidden="true" />
+              <AutocompleteInput
+                label={modoViaje === "hacia" ? "Desde" : "Hacia"}
+                placeholder={
+                  modoViaje === "hacia"
+                    ? "Ingrese dirección de origen"
+                    : "Ingrese dirección de destino"
+                }
+                value={lugar?.formatted_address || ""}
+                onPlaceSelected={(place) => setLugar(place)}
+                containerClassName="buscador-resumen__input-group"
+                inputClassName="buscador-resumen__input"
+                inputProps={{ onFocus: () => setBuscadorExpandido(true) }}
+              />
+              <button
+                type="button"
+                className="buscador-toggle"
+                onClick={toggleBuscador}
+                aria-expanded={buscadorExpandido}
+                aria-controls={buscadorContentId}
+                aria-label="Mostrar opciones del buscador"
+              >
+                <FaChevronDown
+                  className={`buscador-icon${
+                    buscadorExpandido ? " buscador-icon--abierto" : ""
+                  }`}
+                  aria-hidden="true"
+                />
+              </button>
+            </div>
 
-                {/* Contenedor con las mismas clases que en Publicar.jsx */}
+            {buscadorExpandido && (
+              <div id={buscadorContentId} className="buscador-contenido">
                 <div className="input-group" style={{ marginTop: 8 }}>
-                  {/* Selector de dirección (reutiliza .radio-viaje) */}
                   <div className="radio-viaje">
                     <label>
                       <input
@@ -152,11 +144,11 @@ function Home() {
                 <Button type="submit" className="botonPrimario">
                   Buscar
                 </Button>
-              </form>
-            </LoadScript>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </form>
+      </LoadScript>
 
       {mostrarTrayectos && (
         <section ref={resultadosRef} className="seccion-trayectos">


### PR DESCRIPTION
## Summary
- agrega opciones de estilo y propagación de props al componente `AutocompleteInput`
- reestructura el formulario de Home para envolverlo con `LoadScript`, mostrar el Autocomplete en el resumen y condicionar radios/botón al estado expandido
- actualiza los estilos del buscador para soportar el nuevo layout, incluyendo el botón toggle y la variante expandida

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2cf570108832f9be3bc008f9489bb