### PR TITLE
Add trip detail modal for trip cards

### DIFF
--- a/src/components/ModalViaje.css
+++ b/src/components/ModalViaje.css
@@ -1,0 +1,163 @@
+.modal-viaje__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(22, 26, 33, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal-viaje__contenedor {
+  position: relative;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2rem 1.5rem 1.5rem;
+  max-width: 480px;
+  width: 100%;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.15);
+  color: #1f2937;
+}
+
+.modal-viaje__cerrar {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  font-size: 1.125rem;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.modal-viaje__cerrar:hover {
+  color: #111827;
+}
+
+.modal-viaje__encabezado {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.modal-viaje__avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+.modal-viaje__titulo {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.modal-viaje__estrellas {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  color: #9ca3af;
+  font-size: 0.875rem;
+}
+
+.modal-viaje__estrella {
+  color: #d1d5db;
+  font-size: 1rem;
+}
+
+.modal-viaje__estrella--activa {
+  color: #f59e0b;
+}
+
+.modal-viaje__puntaje {
+  margin-left: 0.5rem;
+  font-weight: 500;
+  color: #4b5563;
+}
+
+.modal-viaje__detalle {
+  margin-bottom: 1.5rem;
+}
+
+.modal-viaje__subtitulo {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.modal-viaje__lista {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.modal-viaje__lista li {
+  font-size: 0.95rem;
+  color: #374151;
+}
+
+.modal-viaje__comentario {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: #f9fafb;
+  border-radius: 12px;
+  color: #374151;
+}
+
+.modal-viaje__comentario p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.modal-viaje__acciones {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.modal-viaje__btn {
+  border: none;
+  background: #4f46e5;
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.modal-viaje__btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 15px rgba(79, 70, 229, 0.25);
+}
+
+.modal-viaje__btn--secundario {
+  background: #e5e7eb;
+  color: #1f2937;
+  box-shadow: none;
+}
+
+@media (max-width: 640px) {
+  .modal-viaje__contenedor {
+    padding: 1.5rem 1.25rem 1.25rem;
+  }
+
+  .modal-viaje__encabezado {
+    align-items: flex-start;
+  }
+}

--- a/src/components/ModalViaje.jsx
+++ b/src/components/ModalViaje.jsx
@@ -1,0 +1,104 @@
+import { useId } from "react";
+import { FaStar, FaTimes } from "react-icons/fa";
+import "./ModalViaje.css";
+
+function ModalViaje({ isOpen, viaje, onClose, onVerPerfil }) {
+  const tituloId = useId();
+
+  if (!isOpen || !viaje) {
+    return null;
+  }
+
+  const {
+    nombre,
+    destino,
+    fecha,
+    precio,
+    comentario,
+    rating = 0,
+    reviewsCount = 0,
+  } = viaje;
+
+  const maxEstrellas = 5;
+  const estrellas = Array.from({ length: maxEstrellas }, (_, index) => index + 1);
+
+  return (
+    <div
+      className="modal-viaje__overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={tituloId}
+    >
+      <div className="modal-viaje__contenedor">
+        <button
+          type="button"
+          className="modal-viaje__cerrar"
+          onClick={onClose}
+          aria-label="Cerrar detalle del viaje"
+        >
+          <FaTimes aria-hidden="true" />
+        </button>
+
+        <header className="modal-viaje__encabezado">
+          <div className="modal-viaje__avatar" aria-hidden="true">
+            {nombre?.[0]?.toUpperCase() || "?"}
+          </div>
+          <div>
+            <h3 id={tituloId} className="modal-viaje__titulo">
+              Viaje con {nombre}
+            </h3>
+            <div className="modal-viaje__estrellas" aria-label={`Puntaje ${rating} de ${maxEstrellas}`}>
+              {estrellas.map((valor) => (
+                <FaStar
+                  key={valor}
+                  className={
+                    valor <= Math.round(rating)
+                      ? "modal-viaje__estrella modal-viaje__estrella--activa"
+                      : "modal-viaje__estrella"
+                  }
+                  aria-hidden="true"
+                />
+              ))}
+              <span className="modal-viaje__puntaje">
+                {rating.toFixed(1)} ({reviewsCount} reseñas)
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <section className="modal-viaje__detalle">
+          <h4 className="modal-viaje__subtitulo">Detalles del viaje</h4>
+          <ul className="modal-viaje__lista">
+            <li>
+              <strong>Destino:</strong> {destino}
+            </li>
+            <li>
+              <strong>Fecha y hora:</strong> {fecha}
+            </li>
+            <li>
+              <strong>Costo por asiento:</strong> {precio}
+            </li>
+          </ul>
+        </section>
+
+        {comentario && (
+          <section className="modal-viaje__comentario">
+            <h4 className="modal-viaje__subtitulo">Comentario del conductor</h4>
+            <p>{comentario}</p>
+          </section>
+        )}
+
+        <footer className="modal-viaje__acciones">
+          <button type="button" className="modal-viaje__btn" onClick={onVerPerfil}>
+            Ver perfil del conductor
+          </button>
+          <button type="button" className="modal-viaje__btn modal-viaje__btn--secundario" onClick={onClose}>
+            Cerrar
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+export default ModalViaje;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,6 +4,7 @@ import { LoadScript } from "@react-google-maps/api";
 import FormContainer from "../components/FormContainer";
 import Button from "../components/Button";
 import TarjetaViaje from "../components/TarjetaViaje";
+import ModalViaje from "../components/ModalViaje";
 import { FaSearch, FaChevronDown } from "react-icons/fa";
 import "./Home.css";
 
@@ -13,6 +14,7 @@ function Home() {
   const [modoViaje, setModoViaje] = useState("desde"); // "hacia" | "desde"
   const [lugar, setLugar] = useState(null); // Google Place seleccionado
   const [buscadorExpandido, setBuscadorExpandido] = useState(false);
+  const [viajeSeleccionado, setViajeSeleccionado] = useState(null);
 
   const [mostrarTrayectos, setMostrarTrayectos] = useState(false);
   const resultadosRef = useRef(null);
@@ -42,6 +44,9 @@ function Home() {
       destino: "Plaza Italia",
       fecha: "25 de Octubre. 14:00",
       precio: "$2000 / asiento",
+      comentario: "Punto de encuentro en la entrada principal del barrio.",
+      rating: 4.8,
+      reviewsCount: 26,
     },
     {
       id: 2,
@@ -50,6 +55,9 @@ function Home() {
       destino: "USAL Pilar",
       fecha: "7 de Octubre. · 08:00",
       precio: "$1800 / asiento",
+      comentario: "Nos encontramos en el lote 1260 a las 8:15 en punto.",
+      rating: 4.6,
+      reviewsCount: 18,
     },
     {
       id: 3,
@@ -58,8 +66,19 @@ function Home() {
       destino: "Escobar centro",
       fecha: "10 de Octubre. 16:00",
       precio: "$1500 / asiento",
+      comentario: "Puedo pasar por la garita norte si les queda cómodo.",
+      rating: 5,
+      reviewsCount: 32,
     },
   ];
+
+  const abrirModalViaje = (trayecto) => {
+    setViajeSeleccionado(trayecto);
+  };
+
+  const cerrarModalViaje = () => {
+    setViajeSeleccionado(null);
+  };
 
   return (
     <FormContainer>
@@ -152,10 +171,17 @@ function Home() {
             fecha={t.fecha}
             precio={t.precio}
             onSumarse={() => console.log("Sumarse", t)}
-            onVerMas={() => console.log("Ver más de", t)}
+            onVerMas={() => abrirModalViaje(t)}
           />
         ))}
       </section>
+
+      <ModalViaje
+        isOpen={Boolean(viajeSeleccionado)}
+        viaje={viajeSeleccionado}
+        onClose={cerrarModalViaje}
+        onVerPerfil={() => console.log("Ver perfil de", viajeSeleccionado)}
+      />
     </FormContainer>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable `ModalViaje` component to mostrar detalles del viaje y conductor
- actualizar la página de inicio para abrir el modal al presionar "Ver más" en una tarjeta
- incluir estilos dedicados para la ventana emergente y su contenido

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fd349c90832fa35f93095e7d931d