### PR TITLE
Redesign MisViajes page layout

### DIFF
--- a/src/pages/MisViajes.css
+++ b/src/pages/MisViajes.css
@@ -1,0 +1,249 @@
+.mis-viajes {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 1.5rem;
+  background-color: #f7f5f7;
+  min-height: 100%;
+}
+
+.mis-viajes__encabezado {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 680px;
+}
+
+.mis-viajes__titulo {
+  font-size: 1.75rem;
+  color: #2f2a2d;
+  font-weight: 600;
+  margin: 0;
+}
+
+.mis-viajes__descripcion {
+  margin: 0;
+  color: #6d6568;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.mis-viajes__tabs {
+  display: inline-flex;
+  align-self: flex-start;
+  background-color: #ece7ec;
+  border-radius: 999px;
+  padding: 0.25rem;
+  gap: 0.25rem;
+}
+
+.mis-viajes__tab {
+  border: none;
+  background: transparent;
+  color: #6d6568;
+  font-weight: 500;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mis-viajes__tab:hover,
+.mis-viajes__tab:focus-visible {
+  color: #2f2a2d;
+}
+
+.mis-viajes__tab:focus-visible {
+  outline: 2px solid #c53678;
+  outline-offset: 2px;
+}
+
+.mis-viajes__tab--activa {
+  background: linear-gradient(135deg, #c53678, #eb638b);
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(197, 54, 120, 0.25);
+}
+
+.mis-viajes__panel {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.mis-viajes__grupo {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mis-viajes__subtitulo {
+  font-size: 1rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #c53678;
+  margin: 0;
+  position: relative;
+  padding-bottom: 0.35rem;
+}
+
+.mis-viajes__subtitulo::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 42px;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(197, 54, 120, 0.8), rgba(235, 99, 139, 0.8));
+}
+
+.mis-viajes__lista {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.mis-viajes__estado-vacio {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px dashed rgba(197, 54, 120, 0.35);
+  color: #8c7f86;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.viaje-card {
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid #e4dee3;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: 0 10px 20px rgba(47, 42, 45, 0.04);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.viaje-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(47, 42, 45, 0.08);
+}
+
+.viaje-card--finalizado {
+  background: linear-gradient(180deg, rgba(247, 245, 247, 0.9), rgba(255, 255, 255, 0.95));
+  border-color: rgba(197, 54, 120, 0.2);
+}
+
+.viaje-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.viaje-card__avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #c53678, #eb638b);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.viaje-card__encabezado {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.viaje-card__titulo {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #2f2a2d;
+  font-weight: 600;
+}
+
+.viaje-card__meta {
+  margin: 0;
+  color: #857a80;
+  font-size: 0.85rem;
+  text-transform: capitalize;
+}
+
+.viaje-card__detalles {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.viaje-card__detalles li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.viaje-card__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #9b9096;
+  font-weight: 600;
+}
+
+.viaje-card__valor {
+  color: #443c41;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.viaje-card__nota {
+  border-left: 3px solid rgba(197, 54, 120, 0.3);
+  padding-left: 0.75rem;
+}
+
+.viaje-card__acciones {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.viaje-card__boton {
+  background: linear-gradient(135deg, #c53678, #eb638b);
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.25rem;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.viaje-card__boton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(197, 54, 120, 0.25);
+}
+
+@media (max-width: 768px) {
+  .mis-viajes {
+    padding: 1rem;
+  }
+
+  .mis-viajes__tabs {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .mis-viajes__tab {
+    flex: 1;
+    text-align: center;
+  }
+
+  .viaje-card {
+    padding: 1rem;
+  }
+}

--- a/src/pages/MisViajes.jsx
+++ b/src/pages/MisViajes.jsx
@@ -1,6 +1,285 @@
-// Vista temporal para listar los viajes publicados o reservados del usuario.
+import { useMemo, useState } from "react";
+import "./MisViajes.css";
+
+const formatFecha = (fechaISO) => {
+  const fecha = new Date(fechaISO);
+  return new Intl.DateTimeFormat("es-AR", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(fecha);
+};
+
+const obtenerIniciales = (texto) => {
+  if (!texto) return "?";
+  const partes = texto.trim().split(/\s+/);
+  if (partes.length === 1) {
+    return partes[0][0]?.toUpperCase() || "?";
+  }
+  return (partes[0][0] + partes[partes.length - 1][0]).toUpperCase();
+};
+
+const agruparPorEstado = (viajes) => {
+  const ahora = new Date();
+  const ordenados = [...viajes].sort(
+    (a, b) => new Date(a.fecha) - new Date(b.fecha)
+  );
+
+  const pendientes = ordenados.filter((viaje) => new Date(viaje.fecha) >= ahora);
+  const finalizados = ordenados
+    .filter((viaje) => new Date(viaje.fecha) < ahora)
+    .sort((a, b) => new Date(b.fecha) - new Date(a.fecha));
+
+  return { pendientes, finalizados };
+};
+
+const ViajeCard = ({ viaje, tipo, estado }) => {
+  const esPropio = tipo === "propio";
+  const avatarTexto = esPropio
+    ? viaje.destino?.[0] || viaje.puntoEncuentro?.[0] || "?"
+    : obtenerIniciales(viaje.conductor);
+
+  const accion = (() => {
+    if (estado !== "finalizado") return null;
+    if (esPropio) return "Puntuar pasajero";
+    return "Puntuar conductor";
+  })();
+
+  return (
+    <article
+      className={`viaje-card${estado === "finalizado" ? " viaje-card--finalizado" : ""}`}
+    >
+      <header className="viaje-card__header">
+        <div className="viaje-card__avatar" aria-hidden="true">
+          {avatarTexto}
+        </div>
+        <div className="viaje-card__encabezado">
+          <h4 className="viaje-card__titulo">{viaje.destino}</h4>
+          <p className="viaje-card__meta">Salida {formatFecha(viaje.fecha)}</p>
+        </div>
+      </header>
+
+      <ul className="viaje-card__detalles">
+        <li>
+          <span className="viaje-card__label">Punto de encuentro</span>
+          <span className="viaje-card__valor">{viaje.puntoEncuentro}</span>
+        </li>
+        {esPropio ? (
+          <li>
+            <span className="viaje-card__label">Pasajeros confirmados</span>
+            <span className="viaje-card__valor">
+              {viaje.pasajerosConfirmados} de {viaje.capacidadTotal}
+            </span>
+          </li>
+        ) : (
+          <li>
+            <span className="viaje-card__label">Conductor</span>
+            <span className="viaje-card__valor">{viaje.conductor}</span>
+          </li>
+        )}
+        {!esPropio && (
+          <li>
+            <span className="viaje-card__label">Asiento reservado</span>
+            <span className="viaje-card__valor">{viaje.asientoReservado}</span>
+          </li>
+        )}
+        {viaje.notas && (
+          <li className="viaje-card__nota">
+            <span className="viaje-card__label">Notas</span>
+            <span className="viaje-card__valor">{viaje.notas}</span>
+          </li>
+        )}
+      </ul>
+
+      {accion && (
+        <div className="viaje-card__acciones">
+          <button type="button" className="viaje-card__boton">
+            {accion}
+          </button>
+        </div>
+      )}
+    </article>
+  );
+};
+
 function MisViajes() {
-  return <div>Mis viajes viaje</div>;
+  const [pestaniaActiva, setPestaniaActiva] = useState("propios");
+
+  const viajesPropios = useMemo(() => {
+    const hoy = new Date();
+    hoy.setHours(0, 0, 0, 0);
+    const crearFecha = (diasDesdeHoy, horas, minutos) => {
+      const fecha = new Date(hoy);
+      fecha.setDate(hoy.getDate() + diasDesdeHoy);
+      fecha.setHours(horas, minutos, 0, 0);
+      return fecha.toISOString();
+    };
+
+    return [
+      {
+        id: "prop-1",
+        destino: "USAL Pilar",
+        fecha: crearFecha(2, 8, 15),
+        puntoEncuentro: "Garita Norte - Lote 1260",
+        pasajerosConfirmados: 2,
+        capacidadTotal: 3,
+        notas: "Salgo puntual, llevar cambio si necesitan pagar en efectivo.",
+      },
+      {
+        id: "prop-2",
+        destino: "Centro de Escobar",
+        fecha: crearFecha(-4, 17, 30),
+        puntoEncuentro: "Club House - Estacionamiento",
+        pasajerosConfirmados: 3,
+        capacidadTotal: 4,
+        notas: "Gracias por avisar si se retrasan. Tengo lugar para equipaje chico.",
+      },
+      {
+        id: "prop-3",
+        destino: "Universidad Di Tella",
+        fecha: crearFecha(6, 6, 45),
+        puntoEncuentro: "Entrada principal - Portón Sur",
+        pasajerosConfirmados: 1,
+        capacidadTotal: 3,
+        notas: "Puedo desviar hasta la colectora si alguien lo necesita.",
+      },
+    ];
+  }, []);
+
+  const viajesAjenos = useMemo(() => {
+    const hoy = new Date();
+    hoy.setHours(0, 0, 0, 0);
+    const crearFecha = (diasDesdeHoy, horas, minutos) => {
+      const fecha = new Date(hoy);
+      fecha.setDate(hoy.getDate() + diasDesdeHoy);
+      fecha.setHours(horas, minutos, 0, 0);
+      return fecha.toISOString();
+    };
+
+    return [
+      {
+        id: "aj-1",
+        destino: "CABA - Obelisco",
+        fecha: crearFecha(1, 7, 0),
+        puntoEncuentro: "Rotonda Principal",
+        conductor: "Martín Fernández",
+        asientoReservado: "Asiento 2 de 3",
+        notas: "El viaje incluye peaje, llevar SUBE si quieren combinar.",
+      },
+      {
+        id: "aj-2",
+        destino: "Pilar Centro",
+        fecha: crearFecha(-2, 19, 10),
+        puntoEncuentro: "Garita Sur",
+        conductor: "Valentina Ruiz",
+        asientoReservado: "Asiento 1 de 4",
+        notas: "Gran viaje, conducción muy segura.",
+      },
+      {
+        id: "aj-3",
+        destino: "Colegio St. John",
+        fecha: crearFecha(4, 7, 30),
+        puntoEncuentro: "Playón Deportivo",
+        conductor: "Ignacio Paredes",
+        asientoReservado: "Asiento 3 de 3",
+        notas: "Sale música tranquila durante el viaje.",
+      },
+    ];
+  }, []);
+
+  const datosPropios = useMemo(
+    () => agruparPorEstado(viajesPropios),
+    [viajesPropios]
+  );
+  const datosAjenos = useMemo(() => agruparPorEstado(viajesAjenos), [viajesAjenos]);
+
+  const datosActivos = pestaniaActiva === "propios" ? datosPropios : datosAjenos;
+  const tipoActual = pestaniaActiva === "propios" ? "propio" : "ajeno";
+
+  return (
+    <main className="mis-viajes">
+      <header className="mis-viajes__encabezado">
+        <h1 className="mis-viajes__titulo">Mis viajes</h1>
+        <p className="mis-viajes__descripcion">
+          Consultá rápidamente tus trayectos publicados y los que reservaste, separados
+          por estado para que encuentres lo que necesitás en segundos.
+        </p>
+      </header>
+
+      <div className="mis-viajes__tabs" role="tablist" aria-label="Mis viajes">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={pestaniaActiva === "propios"}
+          className={`mis-viajes__tab${
+            pestaniaActiva === "propios" ? " mis-viajes__tab--activa" : ""
+          }`}
+          onClick={() => setPestaniaActiva("propios")}
+        >
+          Propios
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={pestaniaActiva === "ajenos"}
+          className={`mis-viajes__tab${
+            pestaniaActiva === "ajenos" ? " mis-viajes__tab--activa" : ""
+          }`}
+          onClick={() => setPestaniaActiva("ajenos")}
+        >
+          Ajenos
+        </button>
+      </div>
+
+      <section
+        className="mis-viajes__panel"
+        role="tabpanel"
+        aria-label={pestaniaActiva === "propios" ? "Viajes propios" : "Viajes ajenos"}
+      >
+        <div className="mis-viajes__grupo">
+          <h3 className="mis-viajes__subtitulo">Pendientes</h3>
+          <div className="mis-viajes__lista">
+            {datosActivos.pendientes.length > 0 ? (
+              datosActivos.pendientes.map((viaje) => (
+                <ViajeCard
+                  key={viaje.id}
+                  viaje={viaje}
+                  tipo={tipoActual}
+                  estado="pendiente"
+                />
+              ))
+            ) : (
+              <p className="mis-viajes__estado-vacio">
+                No tenés viajes pendientes en esta sección.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="mis-viajes__grupo">
+          <h3 className="mis-viajes__subtitulo">Finalizados</h3>
+          <div className="mis-viajes__lista">
+            {datosActivos.finalizados.length > 0 ? (
+              datosActivos.finalizados.map((viaje) => (
+                <ViajeCard
+                  key={viaje.id}
+                  viaje={viaje}
+                  tipo={tipoActual}
+                  estado="finalizado"
+                />
+              ))
+            ) : (
+              <p className="mis-viajes__estado-vacio">
+                Todavía no finalizaste viajes en esta sección.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
 }
 
 export default MisViajes;


### PR DESCRIPTION
## Summary
- Redesign the MisViajes page with tabs that separate viajes propios and ajenos
- Present pending and finalised trips in compact cards with contextual actions and messaging
- Add dedicated styling to align the new layout with the existing visual language

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d605343114832fa7dc77b9f40e2c0d