### PR TITLE
Refactor tarjeta de viajes con resumen compacto

### DIFF
--- a/src/components/TarjetaMiViaje.css
+++ b/src/components/TarjetaMiViaje.css
@@ -46,6 +46,36 @@
   gap: 0.25rem;
 }
 
+.viaje-card__resumen {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.viaje-card__resumen-item {
+  background: #f7f5f7;
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.viaje-card__resumen-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9b9096;
+  font-weight: 600;
+}
+
+.viaje-card__resumen-value {
+  color: #2f2a2d;
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
 .viaje-card__titulo {
   margin: 0;
   font-size: 1.1rem;
@@ -86,6 +116,41 @@
   color: #443c41;
   font-size: 0.95rem;
   line-height: 1.4;
+}
+
+.viaje-card__conductor {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(197, 54, 120, 0.18);
+  background: linear-gradient(135deg, rgba(197, 54, 120, 0.08), rgba(255, 255, 255, 0.8));
+}
+
+.viaje-card__conductor-datos {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.viaje-card__whatsapp {
+  background: #25d366;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  white-space: nowrap;
+}
+
+.viaje-card__whatsapp:hover {
+  background: #1eb458;
+  box-shadow: 0 8px 16px rgba(37, 211, 102, 0.3);
+  transform: translateY(-1px);
 }
 
 .viaje-card__nota {

--- a/src/components/TarjetaMiViaje.jsx
+++ b/src/components/TarjetaMiViaje.jsx
@@ -26,6 +26,12 @@ function TarjetaMiViaje({ viaje, tipo, estado }) {
   const avatarTexto = esPropio
     ? viaje.destino?.[0] || viaje.puntoEncuentro?.[0] || "?"
     : obtenerIniciales(viaje.conductor);
+  const direccionTexto = viaje.direccion?.trim() || "Dirección no especificada";
+  const horarioTexto = viaje.fecha ? formatFecha(viaje.fecha) : "Horario no disponible";
+  const whatsappNumero = viaje.contactoConductor
+    ? viaje.contactoConductor.replace(/[^\d]/g, "")
+    : "";
+  const whatsappHref = whatsappNumero ? `https://wa.me/${whatsappNumero}` : null;
 
   const accion = (() => {
     if (estado !== "finalizado") return null;
@@ -43,34 +49,26 @@ function TarjetaMiViaje({ viaje, tipo, estado }) {
         </div>
         <div className="viaje-card__encabezado">
           <h4 className="viaje-card__titulo">{viaje.destino}</h4>
-          <p className="viaje-card__meta">Salida {formatFecha(viaje.fecha)}</p>
+          <p className="viaje-card__meta">Salida {horarioTexto}</p>
         </div>
       </header>
+
+      <div className="viaje-card__resumen">
+        <div className="viaje-card__resumen-item">
+          <span className="viaje-card__resumen-label">Dirección</span>
+          <span className="viaje-card__resumen-value">{direccionTexto}</span>
+        </div>
+        <div className="viaje-card__resumen-item">
+          <span className="viaje-card__resumen-label">Horario</span>
+          <span className="viaje-card__resumen-value">{horarioTexto}</span>
+        </div>
+      </div>
 
       <ul className="viaje-card__detalles">
         <li>
           <span className="viaje-card__label">Punto de encuentro</span>
           <span className="viaje-card__valor">{viaje.puntoEncuentro}</span>
         </li>
-        {esPropio ? (
-          <li>
-            <span className="viaje-card__label">Pasajeros confirmados</span>
-            <span className="viaje-card__valor">
-              {viaje.pasajerosConfirmados} de {viaje.capacidadTotal}
-            </span>
-          </li>
-        ) : (
-          <li>
-            <span className="viaje-card__label">Conductor</span>
-            <span className="viaje-card__valor">{viaje.conductor}</span>
-          </li>
-        )}
-        {!esPropio && (
-          <li>
-            <span className="viaje-card__label">Asiento reservado</span>
-            <span className="viaje-card__valor">{viaje.asientoReservado}</span>
-          </li>
-        )}
         {viaje.notas && (
           <li className="viaje-card__nota">
             <span className="viaje-card__label">Notas</span>
@@ -78,6 +76,25 @@ function TarjetaMiViaje({ viaje, tipo, estado }) {
           </li>
         )}
       </ul>
+
+      {tipo === "ajeno" && (
+        <div className="viaje-card__conductor">
+          <div className="viaje-card__conductor-datos">
+            <span className="viaje-card__label">Conductor</span>
+            <span className="viaje-card__valor">{viaje.conductor || "Por confirmar"}</span>
+          </div>
+          {whatsappHref && (
+            <a
+              className="viaje-card__whatsapp"
+              href={whatsappHref}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Contactar
+            </a>
+          )}
+        </div>
+      )}
 
       {accion && (
         <div className="viaje-card__acciones">
@@ -101,6 +118,8 @@ TarjetaMiViaje.propTypes = {
     conductor: PropTypes.string,
     asientoReservado: PropTypes.string,
     notas: PropTypes.string,
+    direccion: PropTypes.string,
+    contactoConductor: PropTypes.string,
   }).isRequired,
   tipo: PropTypes.oneOf(["propio", "ajeno"]).isRequired,
   estado: PropTypes.oneOf(["pendiente", "finalizado"]).isRequired,


### PR DESCRIPTION
## Summary
- replace the passenger and availability blocks with compact cards that surface the trip address and formatted schedule
- show the conductor block only for external trips, keeping the WhatsApp contact link resilient to missing data
- refresh TarjetaMiViaje styles to support the new layout and compact conductor section

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d6ab4604a8832fa3cb3170980f612a