### PR TITLE
Refine WhatsApp CTA styling on Mis Viajes cards

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -99,6 +99,7 @@ const DATOS_DEMOSTRACION = {
       conductor: "Martín Fernández",
       asientoReservado: "Asiento 2 de 3",
       notas: "El viaje incluye peaje, llevar SUBE si quieren combinar.",
+      whatsapp: "+54 9 11 2345-6789",
     },
     {
       id: "aj-2",
@@ -108,6 +109,7 @@ const DATOS_DEMOSTRACION = {
       conductor: "Valentina Ruiz",
       asientoReservado: "Asiento 1 de 4",
       notas: "Gran viaje, conducción muy segura.",
+      whatsapp: "+54 9 11 9876-5432",
     },
     {
       id: "aj-3",
@@ -117,6 +119,7 @@ const DATOS_DEMOSTRACION = {
       conductor: "Ignacio Paredes",
       asientoReservado: "Asiento 3 de 3",
       notas: "Sale música tranquila durante el viaje.",
+      whatsapp: "+54 9 11 5555-1122",
     },
   ],
   notificaciones: [

--- a/src/components/TarjetaMiViaje.css
+++ b/src/components/TarjetaMiViaje.css
@@ -10,6 +10,7 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+
 .viaje-card:hover {
   transform: translateY(-2px);
   box-shadow: 0 16px 32px rgba(47, 42, 45, 0.08);
@@ -74,6 +75,20 @@
   gap: 0.25rem;
 }
 
+.viaje-card__dato {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.viaje-card__dato .viaje-card__valor {
+  flex: 1;
+}
+
+.viaje-card__dato--conductor {
+  align-items: center;
+}
+
 .viaje-card__label {
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -114,6 +129,46 @@
 .viaje-card__boton:hover {
   background-color: #a12a63;
   transform: translateY(-1px);
+}
+
+.viaje-card__whatsapp {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #23c25e, #1a9f4a);
+  color: #fff;
+  font-size: 0.9rem;
+  box-shadow: 0 4px 12px rgba(35, 194, 94, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.viaje-card__whatsapp:hover,
+.viaje-card__whatsapp:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(35, 194, 94, 0.4);
+  filter: brightness(1.05);
+  outline: none;
+}
+
+.viaje-card__whatsapp svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.viaje-card__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
 }
 
 @media (max-width: 768px) {

--- a/src/components/TarjetaMiViaje.jsx
+++ b/src/components/TarjetaMiViaje.jsx
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { FaWhatsapp } from "react-icons/fa";
 import "./TarjetaMiViaje.css";
 
 const formatFecha = (fechaISO) => {
@@ -21,11 +22,20 @@ const obtenerIniciales = (texto) => {
   return (partes[0][0] + partes[partes.length - 1][0]).toUpperCase();
 };
 
+const crearLinkWhatsapp = (numero) => {
+  if (!numero) return null;
+  const digitos = numero.replace(/\D+/g, "");
+  if (!digitos) return null;
+  return `https://wa.me/${digitos}`;
+};
+
 function TarjetaMiViaje({ viaje, tipo, estado }) {
   const esPropio = tipo === "propio";
   const avatarTexto = esPropio
     ? viaje.destino?.[0] || viaje.puntoEncuentro?.[0] || "?"
     : obtenerIniciales(viaje.conductor);
+
+  const whatsappLink = crearLinkWhatsapp(viaje.whatsapp);
 
   const accion = (() => {
     if (estado !== "finalizado") return null;
@@ -62,7 +72,22 @@ function TarjetaMiViaje({ viaje, tipo, estado }) {
         ) : (
           <li>
             <span className="viaje-card__label">Conductor</span>
-            <span className="viaje-card__valor">{viaje.conductor}</span>
+            <div className="viaje-card__dato viaje-card__dato--conductor">
+              <span className="viaje-card__valor">{viaje.conductor}</span>
+              {whatsappLink && (
+                <a
+                  className="viaje-card__whatsapp"
+                  href={whatsappLink}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <span className="viaje-card__sr-only">
+                    Enviar mensaje por WhatsApp a {viaje.conductor}
+                  </span>
+                  <FaWhatsapp aria-hidden="true" focusable="false" />
+                </a>
+              )}
+            </div>
           </li>
         )}
         {!esPropio && (
@@ -101,6 +126,7 @@ TarjetaMiViaje.propTypes = {
     conductor: PropTypes.string,
     asientoReservado: PropTypes.string,
     notas: PropTypes.string,
+    whatsapp: PropTypes.string,
   }).isRequired,
   tipo: PropTypes.oneOf(["propio", "ajeno"]).isRequired,
   estado: PropTypes.oneOf(["pendiente", "finalizado"]).isRequired,


### PR DESCRIPTION
## Summary
- shrink and restyle the WhatsApp contact chip for Mis Viajes cards
- align the conductor row content so the reduced icon sits correctly next to the name
- add demo WhatsApp numbers so the CTA renders during development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6ab52abcc832f8da4594df72d6152