### PR TITLE
Add icon label for conductor on trip card

### DIFF
--- a/src/components/TarjetaMiViaje.css
+++ b/src/components/TarjetaMiViaje.css
@@ -152,6 +152,21 @@
   font-weight: 600;
 }
 
+.viaje-card__label-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: currentColor;
+}
+
+.viaje-card__label-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
 .viaje-card__valor {
   color: #443c41;
   font-size: 0.95rem;

--- a/src/components/TarjetaMiViaje.jsx
+++ b/src/components/TarjetaMiViaje.jsx
@@ -91,7 +91,19 @@ function TarjetaMiViaje({ viaje, tipo, estado }) {
       {tipo === "ajeno" && (
         <div className="viaje-card__conductor">
           <div className="viaje-card__conductor-datos">
-            <span className="viaje-card__label">Conductor</span>
+            <span
+              className="viaje-card__label viaje-card__label-icon"
+              role="img"
+              aria-label="Conductor"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path d="M5.5 11a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5zm13 0a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5zM3 14.25C3 12.455 4.455 11 6.25 11h11.5C19.545 11 21 12.455 21 14.25v2.5c0 .414-.336.75-.75.75h-.75a2.25 2.25 0 0 1-4.5 0H9.75a2.25 2.25 0 0 1-4.5 0H4.5a.75.75 0 0 1-.75-.75v-2.5zm3.75-.75C5.784 13.5 5 14.284 5 15.25V16.5h1.076a2.25 2.25 0 0 1 3.848 0h9.576V15.25c0-.966-.784-1.75-1.75-1.75H6.75z" />
+              </svg>
+            </span>
             <div className="viaje-card__conductor-identidad">
               <span className="viaje-card__conductor-nombre">
                 {viaje.conductor || "Por confirmar"}


### PR DESCRIPTION
## Summary
- replace the conductor text label with an icon on shared trip cards while keeping an accessible label
- add styles for the new label icon to maintain size, alignment, and color consistency

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d6c751e124832fb89dd9aed8828eda