### PR TITLE
Mostrar modal de confirmación antes de enviar solicitud

### DIFF
--- a/src/components/ModalConfirmacion.css
+++ b/src/components/ModalConfirmacion.css
@@ -1,0 +1,91 @@
+.modal-confirmacion__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal-confirmacion__contenedor {
+  background: #ffffff;
+  border-radius: 12px;
+  max-width: 420px;
+  width: 100%;
+  padding: 24px;
+  box-shadow: 0 20px 25px -15px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.modal-confirmacion__titulo {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: #1f2933;
+}
+
+.modal-confirmacion__descripcion {
+  font-size: 1rem;
+  color: #52606d;
+  margin-bottom: 24px;
+  line-height: 1.5;
+}
+
+.modal-confirmacion__acciones {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.modal-confirmacion__btn {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.modal-confirmacion__btn:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.modal-confirmacion__btn--primario {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 10px 15px -10px rgba(37, 99, 235, 0.8);
+}
+
+.modal-confirmacion__btn--primario:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 20px -15px rgba(37, 99, 235, 0.9);
+}
+
+.modal-confirmacion__btn--secundario {
+  background: #f5f7fa;
+  color: #52606d;
+  border: 1px solid #d2d6dc;
+}
+
+.modal-confirmacion__btn--secundario:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 20px -15px rgba(82, 96, 109, 0.3);
+}
+
+@media (max-width: 480px) {
+  .modal-confirmacion__contenedor {
+    padding: 20px;
+  }
+
+  .modal-confirmacion__acciones {
+    flex-direction: column-reverse;
+  }
+
+  .modal-confirmacion__btn {
+    width: 100%;
+  }
+}

--- a/src/components/ModalConfirmacion.jsx
+++ b/src/components/ModalConfirmacion.jsx
@@ -1,0 +1,66 @@
+import { useId } from "react";
+import "./ModalConfirmacion.css";
+
+function ModalConfirmacion({
+  isOpen,
+  titulo,
+  descripcion,
+  onConfirm,
+  onCancel,
+  confirmText = "Confirmar",
+  cancelText = "Cancelar",
+}) {
+  const tituloId = useId();
+  const descripcionId = useId();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onCancel?.();
+    }
+  };
+
+  return (
+    <div
+      className="modal-confirmacion__overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={tituloId}
+      aria-describedby={descripcion ? descripcionId : undefined}
+      onClick={handleOverlayClick}
+    >
+      <div className="modal-confirmacion__contenedor">
+        <h3 id={tituloId} className="modal-confirmacion__titulo">
+          {titulo}
+        </h3>
+        {descripcion && (
+          <p id={descripcionId} className="modal-confirmacion__descripcion">
+            {descripcion}
+          </p>
+        )}
+
+        <div className="modal-confirmacion__acciones">
+          <button
+            type="button"
+            className="modal-confirmacion__btn modal-confirmacion__btn--secundario"
+            onClick={onCancel}
+          >
+            {cancelText}
+          </button>
+          <button
+            type="button"
+            className="modal-confirmacion__btn modal-confirmacion__btn--primario"
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalConfirmacion;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import FormContainer from "../components/FormContainer";
 import Button from "../components/Button";
 import TarjetaViaje from "../components/TarjetaViaje";
 import ModalViaje from "../components/ModalViaje";
+import ModalConfirmacion from "../components/ModalConfirmacion";
 import { FaSearch, FaChevronDown } from "react-icons/fa";
 import "./Home.css";
 
@@ -25,6 +26,7 @@ function Home({
   const [seRealizoBusqueda, setSeRealizoBusqueda] = useState(false);
   const resultadosRef = useRef(null);
   const buscadorContentId = useId();
+  const [viajeAConfirmar, setViajeAConfirmar] = useState(null);
 
   useEffect(() => {
     // Al recibir nuevos viajes (por ejemplo, desde el backend) se muestran automáticamente.
@@ -62,7 +64,18 @@ function Home({
   };
 
   const handleSumarse = (trayecto) => {
-    onSumarseViaje?.(trayecto);
+    setViajeAConfirmar(trayecto);
+  };
+
+  const cerrarConfirmacion = () => {
+    setViajeAConfirmar(null);
+  };
+
+  const confirmarSumarse = () => {
+    if (viajeAConfirmar) {
+      onSumarseViaje?.(viajeAConfirmar);
+    }
+    setViajeAConfirmar(null);
   };
 
   const handleVerPerfil = () => {
@@ -179,6 +192,22 @@ function Home({
         viaje={viajeSeleccionado}
         onClose={cerrarModalViaje}
         onVerPerfil={handleVerPerfil}
+      />
+
+      <ModalConfirmacion
+        isOpen={Boolean(viajeAConfirmar)}
+        titulo="Confirmar solicitud"
+        descripcion={
+          viajeAConfirmar
+            ? `¿Desea enviar una solicitud a ${
+                viajeAConfirmar.nombre || "el conductor"
+              } para sumarse al viaje?`
+            : ""
+        }
+        confirmText="Enviar solicitud"
+        cancelText="Cancelar"
+        onConfirm={confirmarSumarse}
+        onCancel={cerrarConfirmacion}
       />
     </FormContainer>
   );


### PR DESCRIPTION
## Summary
- crear un modal de confirmación reutilizable para solicitar unirse a un viaje
- actualizar la pantalla de Home para abrir el modal al presionar "Sumarse" y enviar la solicitud solo tras confirmar

## Testing
- CI=true npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d992fc0540832f9b6f4cec1cafa5c5