### PR TITLE
Add passenger profile page and navigation flow

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import MainLayout from "./layouts/MainLayout";
 import Publicar from "./pages/Publicar";
 import NotificationPage from "./pages/NotificationPage";
 import MisViajes from "./pages/MisViajes";
+import PerfilPasajero from "./pages/PerfilPasajero";
 
 // ==== Datos de demostración ====
 // Se definen fuera de los componentes para que puedan reemplazarse fácilmente
@@ -78,6 +79,21 @@ const DATOS_DEMOSTRACION = {
           apellido: "Giménez",
           avatar: "https://i.pravatar.cc/120?img=32",
           estado: "aceptado",
+          barrio: "Haras Santa María",
+          lote: "1342",
+          telefono: "+54 9 11 4567-1234",
+          resenas: [
+            {
+              id: "prop-1-p1-r1",
+              autor: "Martín F.",
+              comentario: "Muy puntual y respetuosa durante los viajes.",
+            },
+            {
+              id: "prop-1-p1-r2",
+              autor: "Laura P.",
+              comentario: "Siempre avisa con tiempo si surge algún cambio.",
+            },
+          ],
         },
         {
           id: "prop-1-p2",
@@ -85,6 +101,21 @@ const DATOS_DEMOSTRACION = {
           apellido: "Bustos",
           avatar: "https://i.pravatar.cc/120?img=12",
           estado: "pendiente",
+          barrio: "Haras Santa María",
+          lote: "1180",
+          telefono: "+54 9 11 4789-6654",
+          resenas: [
+            {
+              id: "prop-1-p2-r1",
+              autor: "Gonzalo H.",
+              comentario: "Buena comunicación y siempre llega con casco para la bici plegable.",
+            },
+            {
+              id: "prop-1-p2-r2",
+              autor: "Sofía G.",
+              comentario: "Compartimos viaje a diario, muy amable.",
+            },
+          ],
         },
         {
           id: "prop-1-p3",
@@ -92,6 +123,16 @@ const DATOS_DEMOSTRACION = {
           apellido: "Nuñez",
           avatar: "https://i.pravatar.cc/120?img=45",
           estado: "pendiente",
+          barrio: "Haras Santa María",
+          lote: "1275",
+          telefono: "+54 9 11 5123-9087",
+          resenas: [
+            {
+              id: "prop-1-p3-r1",
+              autor: "Valentina R.",
+              comentario: "Siempre lleva mate y lo comparte con el grupo.",
+            },
+          ],
         },
       ],
     },
@@ -111,6 +152,21 @@ const DATOS_DEMOSTRACION = {
           apellido: "Sosa",
           avatar: "https://i.pravatar.cc/120?img=5",
           estado: "aceptado",
+          barrio: "Haras Santa María",
+          lote: "890",
+          telefono: "+54 9 11 4455-2266",
+          resenas: [
+            {
+              id: "prop-2-p1-r1",
+              autor: "Ignacio P.",
+              comentario: "Excelente compañera de viaje, muy organizada.",
+            },
+            {
+              id: "prop-2-p1-r2",
+              autor: "Carla N.",
+              comentario: "Siempre trae snacks para compartir.",
+            },
+          ],
         },
         {
           id: "prop-2-p2",
@@ -118,6 +174,16 @@ const DATOS_DEMOSTRACION = {
           apellido: "Herrera",
           avatar: "https://i.pravatar.cc/120?img=39",
           estado: "aceptado",
+          barrio: "Haras Santa María",
+          lote: "965",
+          telefono: "+54 9 11 4785-3344",
+          resenas: [
+            {
+              id: "prop-2-p2-r1",
+              autor: "Martín B.",
+              comentario: "Siempre ayuda con el equipaje pesado.",
+            },
+          ],
         },
         {
           id: "prop-2-p3",
@@ -125,6 +191,16 @@ const DATOS_DEMOSTRACION = {
           apellido: "Martínez",
           avatar: "https://i.pravatar.cc/120?img=16",
           estado: "pendiente",
+          barrio: "Haras Santa María",
+          lote: "1042",
+          telefono: "+54 9 11 4332-9090",
+          resenas: [
+            {
+              id: "prop-2-p3-r1",
+              autor: "Valentina R.",
+              comentario: "Muy amable, suele compartir playlists.",
+            },
+          ],
         },
       ],
     },
@@ -144,6 +220,16 @@ const DATOS_DEMOSTRACION = {
           apellido: "Rossi",
           avatar: "https://i.pravatar.cc/120?img=27",
           estado: "aceptado",
+          barrio: "Haras Santa María",
+          lote: "765",
+          telefono: "+54 9 11 4556-7788",
+          resenas: [
+            {
+              id: "prop-3-p1-r1",
+              autor: "Laura S.",
+              comentario: "Siempre ofrece ayuda para coordinar la logística.",
+            },
+          ],
         },
         {
           id: "prop-3-p2",
@@ -151,6 +237,16 @@ const DATOS_DEMOSTRACION = {
           apellido: "Quintana",
           avatar: "https://i.pravatar.cc/120?img=48",
           estado: "pendiente",
+          barrio: "Haras Santa María",
+          lote: "810",
+          telefono: "+54 9 11 4677-2211",
+          resenas: [
+            {
+              id: "prop-3-p2-r1",
+              autor: "Diego R.",
+              comentario: "Gran compañía, le encanta conversar de música.",
+            },
+          ],
         },
       ],
     },
@@ -272,6 +368,7 @@ function AppRoutes({
             />
           }
         />
+        <Route path="/perfil-pasajero/:id" element={<PerfilPasajero />} />
         <Route
           path="/notificaciones"
           element={

--- a/src/components/ModalPasajeros.css
+++ b/src/components/ModalPasajeros.css
@@ -87,6 +87,22 @@
   gap: 12px;
 }
 
+.modal-pasajeros__avatar-boton {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-pasajeros__avatar-boton:focus-visible {
+  outline: 3px solid #1976d2;
+  outline-offset: 2px;
+  border-radius: 50%;
+}
+
 .modal-pasajeros__avatar {
   width: 44px;
   height: 44px;
@@ -101,6 +117,9 @@
   align-items: center;
   justify-content: center;
   font-weight: 600;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
 }
 
 .modal-pasajeros__nombre {

--- a/src/components/ModalPasajeros.jsx
+++ b/src/components/ModalPasajeros.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import { useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { FiCheck, FiX } from "react-icons/fi";
 import "./ModalPasajeros.css";
 
@@ -18,7 +19,11 @@ function ModalPasajeros({
   fecha,
   onAceptarPasajero,
   onRechazarPasajero,
+  viajeId,
 }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const { aceptados, pendientes } = useMemo(() => {
     const aceptadosLista = [];
     const pendientesLista = [];
@@ -37,6 +42,42 @@ function ModalPasajeros({
   if (!abierto) {
     return null;
   }
+
+  const manejarClickPasajero = (pasajero) => {
+    navigate(`/perfil-pasajero/${pasajero.id}`, {
+      state: {
+        pasajero,
+        from: {
+          pathname: location.pathname,
+          state: {
+            viajeId,
+            reabrirModal: true,
+          },
+        },
+      },
+    });
+  };
+
+  const renderAvatarInteractivo = (pasajero) => (
+    <button
+      type="button"
+      className="modal-pasajeros__avatar-boton"
+      onClick={() => manejarClickPasajero(pasajero)}
+      aria-label={`Ver perfil de ${pasajero.nombre} ${pasajero.apellido}`}
+    >
+      {pasajero.avatar ? (
+        <img
+          className="modal-pasajeros__avatar"
+          src={pasajero.avatar}
+          alt=""
+        />
+      ) : (
+        <span className="modal-pasajeros__avatar modal-pasajeros__avatar--placeholder">
+          {obtenerIniciales(pasajero.nombre, pasajero.apellido)}
+        </span>
+      )}
+    </button>
+  );
 
   return (
     <div className="modal-pasajeros" role="dialog" aria-modal="true">
@@ -75,17 +116,7 @@ function ModalPasajeros({
             <ul className="modal-pasajeros__lista">
               {aceptados.map((pasajero) => (
                 <li key={pasajero.id} className="modal-pasajeros__item">
-                  {pasajero.avatar ? (
-                    <img
-                      className="modal-pasajeros__avatar"
-                      src={pasajero.avatar}
-                      alt={`${pasajero.nombre} ${pasajero.apellido}`}
-                    />
-                  ) : (
-                    <span className="modal-pasajeros__avatar modal-pasajeros__avatar--placeholder">
-                      {obtenerIniciales(pasajero.nombre, pasajero.apellido)}
-                    </span>
-                  )}
+                  {renderAvatarInteractivo(pasajero)}
                   <span className="modal-pasajeros__nombre">
                     {pasajero.nombre} {pasajero.apellido}
                   </span>
@@ -103,17 +134,7 @@ function ModalPasajeros({
             <ul className="modal-pasajeros__lista">
               {pendientes.map((pasajero) => (
                 <li key={pasajero.id} className="modal-pasajeros__item">
-                  {pasajero.avatar ? (
-                    <img
-                      className="modal-pasajeros__avatar"
-                      src={pasajero.avatar}
-                      alt={`${pasajero.nombre} ${pasajero.apellido}`}
-                    />
-                  ) : (
-                    <span className="modal-pasajeros__avatar modal-pasajeros__avatar--placeholder">
-                      {obtenerIniciales(pasajero.nombre, pasajero.apellido)}
-                    </span>
-                  )}
+                  {renderAvatarInteractivo(pasajero)}
                   <span className="modal-pasajeros__nombre">
                     {pasajero.nombre} {pasajero.apellido}
                   </span>
@@ -157,6 +178,16 @@ ModalPasajeros.propTypes = {
       nombre: PropTypes.string.isRequired,
       apellido: PropTypes.string.isRequired,
       avatar: PropTypes.string,
+      barrio: PropTypes.string,
+      lote: PropTypes.string,
+      telefono: PropTypes.string,
+      resenas: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string.isRequired,
+          autor: PropTypes.string,
+          comentario: PropTypes.string,
+        })
+      ),
       estado: PropTypes.oneOf(["aceptado", "pendiente", "rechazado"]).isRequired,
     })
   ),
@@ -164,6 +195,7 @@ ModalPasajeros.propTypes = {
   fecha: PropTypes.string,
   onAceptarPasajero: PropTypes.func.isRequired,
   onRechazarPasajero: PropTypes.func.isRequired,
+  viajeId: PropTypes.string,
 };
 
 ModalPasajeros.defaultProps = {
@@ -171,6 +203,7 @@ ModalPasajeros.defaultProps = {
   pasajeros: [],
   destino: "",
   fecha: undefined,
+  viajeId: undefined,
 };
 
 export default ModalPasajeros;

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -21,7 +21,9 @@ const MainLayout = () => {
     "/notificaciones": "Notificaciones",
   };
 
-  const tituloHeader = titulosPorRuta[location.pathname] || "";
+  const tituloHeader = location.pathname.startsWith("/perfil-pasajero")
+    ? "Perfil del pasajero"
+    : titulosPorRuta[location.pathname] || "";
 
   const abrirMenuLateral = () => {
     setMenuVisible((prev) => !prev);

--- a/src/pages/MisViajes.jsx
+++ b/src/pages/MisViajes.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import TarjetaMiViaje from "../components/TarjetaMiViaje";
 import ModalPasajeros from "../components/ModalPasajeros";
 import "./MisViajes.css";
@@ -20,10 +21,36 @@ function MisViajes({ viajesPropios = [], viajesAjenos = [], pestaniaInicial = "p
   const [viajesPropiosEstado, setViajesPropiosEstado] = useState(viajesPropios);
   const [viajeSeleccionado, setViajeSeleccionado] = useState(null);
   const [modalPasajerosAbierto, setModalPasajerosAbierto] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     setViajesPropiosEstado(viajesPropios);
   }, [viajesPropios]);
+
+  useEffect(() => {
+    const locationState = location.state;
+
+    if (locationState?.viajeId && locationState?.reabrirModal) {
+      const viaje = viajesPropiosEstado.find(
+        (item) => item.id === locationState.viajeId
+      );
+
+      if (viaje) {
+        setPestaniaActiva("propios");
+        setViajeSeleccionado(viaje);
+        setModalPasajerosAbierto(true);
+      }
+
+      const { viajeId: _viajeId, reabrirModal: _reabrirModal, ...restoEstado } =
+        locationState;
+
+      navigate(location.pathname, {
+        replace: true,
+        state: Object.keys(restoEstado).length > 0 ? restoEstado : undefined,
+      });
+    }
+  }, [location, navigate, viajesPropiosEstado]);
 
   const viajeSeleccionadoId = viajeSeleccionado?.id || null;
 
@@ -178,6 +205,7 @@ function MisViajes({ viajesPropios = [], viajesAjenos = [], pestaniaInicial = "p
           fecha={viajeSeleccionado.fecha}
           onAceptarPasajero={handleAceptarPasajero}
           onRechazarPasajero={handleRechazarPasajero}
+          viajeId={viajeSeleccionado.id}
         />
       )}
     </main>

--- a/src/pages/PerfilPasajero.css
+++ b/src/pages/PerfilPasajero.css
@@ -1,0 +1,148 @@
+.perfil-pasajero {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.perfil-pasajero__encabezado {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.perfil-pasajero__boton-volver {
+  background: #f0f4f8;
+  color: #0d47a1;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.perfil-pasajero__boton-volver:hover {
+  background: #e1ecfa;
+}
+
+.perfil-pasajero__identidad {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px 20px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+}
+
+.perfil-pasajero__avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 8px 20px rgba(13, 71, 161, 0.2);
+}
+
+.perfil-pasajero__avatar--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #e3f2fd;
+  color: #0d47a1;
+  font-size: 2.5rem;
+  font-weight: 700;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+}
+
+.perfil-pasajero__nombre {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #1f2933;
+}
+
+.perfil-pasajero__dato {
+  margin: 0;
+  color: #52606d;
+}
+
+.perfil-pasajero__identificador {
+  margin: 0;
+  color: #7b8794;
+  font-size: 0.9rem;
+}
+
+.perfil-pasajero__resenas {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px 20px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+}
+
+.perfil-pasajero__subtitulo {
+  margin: 0 0 12px;
+  font-size: 1.35rem;
+  color: #1f2933;
+}
+
+.perfil-pasajero__lista-resenas {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.perfil-pasajero__resena-item {
+  background: #f7fafc;
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.perfil-pasajero__resena-autor {
+  margin: 0 0 4px;
+  font-weight: 600;
+  color: #0d47a1;
+}
+
+.perfil-pasajero__resena-texto {
+  margin: 0;
+  color: #334155;
+}
+
+.perfil-pasajero__mensaje-vacio {
+  margin: 0;
+  color: #52606d;
+}
+
+.perfil-pasajero__mensaje-error {
+  background: #fff5f5;
+  border-radius: 16px;
+  padding: 24px 20px;
+  text-align: center;
+  color: #a61b1b;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.05);
+}
+
+@media (max-width: 600px) {
+  .perfil-pasajero {
+    padding: 16px;
+    gap: 20px;
+  }
+
+  .perfil-pasajero__avatar {
+    width: 96px;
+    height: 96px;
+  }
+
+  .perfil-pasajero__avatar--placeholder {
+    width: 96px;
+    height: 96px;
+  }
+}

--- a/src/pages/PerfilPasajero.jsx
+++ b/src/pages/PerfilPasajero.jsx
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import "./PerfilPasajero.css";
+
+const obtenerIniciales = (nombre = "", apellido = "") => {
+  const inicialNombre = nombre.trim()[0];
+  const inicialApellido = apellido.trim()[0];
+
+  return `${inicialNombre || ""}${inicialApellido || ""}`.toUpperCase() || "?";
+};
+
+function PerfilPasajero() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { id } = useParams();
+  const state = location.state || {};
+  const pasajero = state.pasajero || {};
+
+  const nombreCompleto = useMemo(() => {
+    const partes = [pasajero.nombre, pasajero.apellido].filter(Boolean);
+    return partes.length > 0 ? partes.join(" ") : "Pasajero sin nombre";
+  }, [pasajero]);
+
+  const ubicacionTexto = useMemo(() => {
+    const partes = [pasajero.barrio];
+    if (pasajero.lote) {
+      partes.push(`Lote ${pasajero.lote}`);
+    }
+    return partes.filter(Boolean).join(" · ") || "Ubicación no disponible";
+  }, [pasajero]);
+
+  const telefonoTexto = pasajero.telefono || "Teléfono no informado";
+  const resenas = pasajero.resenas || [];
+
+  const handleVolver = () => {
+    if (state?.from?.pathname) {
+      navigate(state.from.pathname, { state: state.from.state });
+    } else {
+      navigate(-1);
+    }
+  };
+
+  const mostrarDatos = Boolean(pasajero && Object.keys(pasajero).length > 0);
+
+  return (
+    <div className="perfil-pasajero">
+      <header className="perfil-pasajero__encabezado">
+        <button type="button" className="perfil-pasajero__boton-volver" onClick={handleVolver}>
+          Volver
+        </button>
+      </header>
+
+      {mostrarDatos ? (
+        <>
+          <section className="perfil-pasajero__identidad" aria-labelledby="perfil-pasajero-nombre">
+            {pasajero.avatar ? (
+              <img
+                className="perfil-pasajero__avatar"
+                src={pasajero.avatar}
+                alt={`Avatar de ${nombreCompleto}`}
+              />
+            ) : (
+              <span className="perfil-pasajero__avatar perfil-pasajero__avatar--placeholder" aria-hidden="true">
+                {obtenerIniciales(pasajero.nombre, pasajero.apellido)}
+              </span>
+            )}
+            <h1 id="perfil-pasajero-nombre" className="perfil-pasajero__nombre">
+              {nombreCompleto}
+            </h1>
+            <p className="perfil-pasajero__dato">{ubicacionTexto}</p>
+            <p className="perfil-pasajero__dato">{telefonoTexto}</p>
+            <p className="perfil-pasajero__identificador">ID del pasajero: {pasajero.id || id}</p>
+          </section>
+
+          <section className="perfil-pasajero__resenas" aria-labelledby="perfil-pasajero-resenas">
+            <h2 id="perfil-pasajero-resenas" className="perfil-pasajero__subtitulo">
+              Reseñas
+            </h2>
+            {resenas.length > 0 ? (
+              <ul className="perfil-pasajero__lista-resenas">
+                {resenas.map((resena) => (
+                  <li key={resena.id} className="perfil-pasajero__resena-item">
+                    <p className="perfil-pasajero__resena-autor">{resena.autor || "Vecino"}</p>
+                    <p className="perfil-pasajero__resena-texto">{resena.comentario}</p>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="perfil-pasajero__mensaje-vacio">
+                Aún no hay reseñas cargadas para este pasajero.
+              </p>
+            )}
+          </section>
+        </>
+      ) : (
+        <section className="perfil-pasajero__mensaje-error">
+          <h1 className="perfil-pasajero__subtitulo">No se encontró la información del pasajero</h1>
+          <p>Intentá volver atrás y seleccionar nuevamente desde la lista de pasajeros.</p>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default PerfilPasajero;


### PR DESCRIPTION
## Summary
- create a dedicated passenger profile page that shows identity details, reviews, and a return control
- wire the new profile route into the main layout and enable the passengers modal to deep-link into it with preserved state
- reopen the passengers modal automatically when returning to "Mis viajes" and update layout headers to cover the new route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d99af7eb48832f95b6c393dbb44560