### PR TITLE
Add rating modal for completed trips

### DIFF
--- a/src/components/ModalPuntuacion.css
+++ b/src/components/ModalPuntuacion.css
@@ -1,0 +1,272 @@
+.modal-puntuacion {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.modal-puntuacion__fondo {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.55);
+  pointer-events: auto;
+}
+
+.modal-puntuacion__contenedor {
+  position: relative;
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 30px 60px -25px rgba(15, 23, 42, 0.35);
+  width: min(760px, 92vw);
+  max-height: min(85vh, 900px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  pointer-events: auto;
+}
+
+.modal-puntuacion__encabezado {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 24px 32px 16px;
+  border-bottom: 1px solid rgba(203, 213, 225, 0.6);
+}
+
+.modal-puntuacion__titulo {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 4px;
+}
+
+.modal-puntuacion__descripcion {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.modal-puntuacion__fecha {
+  display: block;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.modal-puntuacion__cerrar {
+  background: none;
+  border: none;
+  color: #6b7280;
+  padding: 6px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.modal-puntuacion__cerrar:hover,
+.modal-puntuacion__cerrar:focus-visible {
+  background: rgba(251, 191, 188, 0.25);
+  color: #ef4444;
+  outline: none;
+}
+
+.modal-puntuacion__formulario {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  flex: 1;
+}
+
+.modal-puntuacion__contenido {
+  padding: 8px 32px 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.modal-puntuacion__tarjeta {
+  border: 1px solid rgba(203, 213, 225, 0.55);
+  border-radius: 14px;
+  padding: 20px 24px;
+  background: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.modal-puntuacion__tarjeta-encabezado {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.modal-puntuacion__tarjeta-titulo {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.modal-puntuacion__tarjeta-detalle {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.modal-puntuacion__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #f1f5f9;
+  color: #1f2937;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+}
+
+.modal-puntuacion__avatar--placeholder {
+  border: 1px solid rgba(148, 163, 184, 0.5);
+}
+
+.modal-puntuacion__campos {
+  display: grid;
+  gap: 16px;
+}
+
+.modal-puntuacion__campo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal-puntuacion__campo-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.modal-puntuacion__estrellas {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.modal-puntuacion__estrella-boton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: inherit;
+  transition: transform 0.2s ease;
+}
+
+.modal-puntuacion__estrella-boton:hover {
+  transform: scale(1.05);
+}
+
+.modal-puntuacion__valor {
+  font-size: 0.85rem;
+  color: #4b5563;
+  margin-left: 4px;
+}
+
+.modal-puntuacion__textarea {
+  min-height: 96px;
+  border-radius: 10px;
+  border: 1px solid rgba(203, 213, 225, 0.8);
+  padding: 12px;
+  resize: vertical;
+  font-size: 0.95rem;
+  font-family: inherit;
+  color: #111827;
+  background: #ffffff;
+}
+
+.modal-puntuacion__textarea:focus {
+  outline: 2px solid rgba(255, 88, 65, 0.35);
+  border-color: #ff5841;
+}
+
+.modal-puntuacion__mensaje-vacio {
+  padding: 24px;
+  text-align: center;
+  color: #6b7280;
+  background: #f8fafc;
+  border-radius: 12px;
+  border: 1px dashed rgba(203, 213, 225, 0.7);
+}
+
+.modal-puntuacion__acciones {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 20px 32px 28px;
+  border-top: 1px solid rgba(203, 213, 225, 0.6);
+  background: #ffffff;
+}
+
+.modal-puntuacion__boton {
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 10px 22px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.modal-puntuacion__boton--secundario {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.modal-puntuacion__boton--secundario:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px -18px rgba(30, 64, 175, 0.55);
+}
+
+.modal-puntuacion__boton--primario {
+  background: #ff5841;
+  color: #ffffff;
+}
+
+.modal-puntuacion__boton--primario:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 25px -18px rgba(251, 96, 76, 0.6);
+}
+
+@media (max-width: 640px) {
+  .modal-puntuacion__contenedor {
+    width: 94vw;
+    border-radius: 16px;
+  }
+
+  .modal-puntuacion__encabezado {
+    padding: 20px 20px 14px;
+  }
+
+  .modal-puntuacion__contenido {
+    padding: 8px 20px 0;
+  }
+
+  .modal-puntuacion__tarjeta {
+    padding: 18px 18px;
+  }
+
+  .modal-puntuacion__acciones {
+    padding: 16px 20px 22px;
+  }
+}

--- a/src/components/ModalPuntuacion.jsx
+++ b/src/components/ModalPuntuacion.jsx
@@ -1,0 +1,369 @@
+import { useEffect, useId, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import { FaStar, FaTimes } from "react-icons/fa";
+import "./ModalPuntuacion.css";
+
+const ESTRELLAS = Array.from({ length: 5 }, (_, index) => index + 1);
+
+const ESTADO_INICIAL_CONDUCTOR = {
+  puntualidad: 0,
+  amabilidad: 0,
+  conduccionSegura: 0,
+  comentario: "",
+};
+
+const crearEstadoInicialPasajeros = (pasajeros = []) =>
+  pasajeros.reduce((acumulador, pasajero) => {
+    acumulador[pasajero.id] = {
+      puntualidad: 0,
+      amabilidad: 0,
+      general: 0,
+      comentario: "",
+    };
+    return acumulador;
+  }, {});
+
+function ModalPuntuacion({ abierto, tipo, viaje, onCerrar, onConfirmar }) {
+  const tituloId = useId();
+  const [calificacionesPasajeros, setCalificacionesPasajeros] = useState({});
+  const [calificacionConductor, setCalificacionConductor] = useState(
+    ESTADO_INICIAL_CONDUCTOR
+  );
+
+  const pasajerosCalificables = useMemo(() => {
+    if (tipo !== "propio" || !viaje) return [];
+
+    return (viaje.pasajeros || []).filter(
+      (pasajero) => pasajero.estado === "aceptado"
+    );
+  }, [tipo, viaje]);
+
+  useEffect(() => {
+    if (!abierto) return;
+
+    if (tipo === "propio") {
+      setCalificacionesPasajeros(
+        crearEstadoInicialPasajeros(pasajerosCalificables)
+      );
+    } else if (tipo === "ajeno") {
+      setCalificacionConductor(ESTADO_INICIAL_CONDUCTOR);
+    }
+  }, [abierto, tipo, pasajerosCalificables]);
+
+  if (!abierto || !viaje) {
+    return null;
+  }
+
+  const manejarClickEstrella = (valorActual, valorNuevo, onChange) => {
+    const nuevoValor = valorActual === valorNuevo ? 0 : valorNuevo;
+    onChange(nuevoValor);
+  };
+
+  const renderEstrellas = (valorActual, onChange, etiqueta) => (
+    <div className="modal-puntuacion__estrellas" role="radiogroup" aria-label={etiqueta}>
+      {ESTRELLAS.map((valor) => (
+        <button
+          key={valor}
+          type="button"
+          className={`modal-viaje__estrella modal-puntuacion__estrella-boton${
+            valor <= valorActual ? " modal-viaje__estrella--activa" : ""
+          }`}
+          onClick={() => manejarClickEstrella(valorActual, valor, onChange)}
+          aria-label={`${valor} estrella${valor === 1 ? "" : "s"}`}
+        >
+          <FaStar aria-hidden="true" />
+        </button>
+      ))}
+      <span className="modal-puntuacion__valor">{valorActual}</span>
+    </div>
+  );
+
+  const manejarCambioPasajero = (pasajeroId, campo, valor) => {
+    setCalificacionesPasajeros((previo) => ({
+      ...previo,
+      [pasajeroId]: {
+        ...previo[pasajeroId],
+        [campo]: valor,
+      },
+    }));
+  };
+
+  const manejarCambioConductor = (campo, valor) => {
+    setCalificacionConductor((previo) => ({
+      ...previo,
+      [campo]: valor,
+    }));
+  };
+
+  const manejarConfirmar = (evento) => {
+    evento.preventDefault();
+
+    if (tipo === "propio") {
+      const calificaciones = Object.entries(calificacionesPasajeros).map(
+        ([pasajeroId, datos]) => ({
+          pasajeroId,
+          ...datos,
+        })
+      );
+
+      onConfirmar({
+        tipo: "propio",
+        viajeId: viaje.id,
+        destino: viaje.destino,
+        calificaciones,
+      });
+    } else {
+      onConfirmar({
+        tipo: "ajeno",
+        viajeId: viaje.id,
+        destino: viaje.destino,
+        conductor: viaje.conductor,
+        calificacion: calificacionConductor,
+      });
+    }
+  };
+
+  return (
+    <div className="modal-puntuacion" role="dialog" aria-modal="true" aria-labelledby={tituloId}>
+      <div className="modal-puntuacion__contenedor">
+        <header className="modal-puntuacion__encabezado">
+          <div>
+            <h2 id={tituloId} className="modal-puntuacion__titulo">
+              {tipo === "propio" ? "Puntuar pasajeros" : "Puntuar conductor"}
+            </h2>
+            <p className="modal-puntuacion__descripcion">
+              {viaje.destino}
+              {viaje.fecha && (
+                <span className="modal-puntuacion__fecha">
+                  {new Intl.DateTimeFormat("es-AR", {
+                    weekday: "short",
+                    day: "numeric",
+                    month: "long",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  }).format(new Date(viaje.fecha))}
+                </span>
+              )}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="modal-puntuacion__cerrar"
+            onClick={onCerrar}
+            aria-label="Cerrar"
+          >
+            <FaTimes aria-hidden="true" />
+          </button>
+        </header>
+
+        <form className="modal-puntuacion__formulario" onSubmit={manejarConfirmar}>
+          {tipo === "propio" ? (
+            <div className="modal-puntuacion__contenido">
+              {pasajerosCalificables.length > 0 ? (
+                pasajerosCalificables.map((pasajero) => {
+                  const calificacionActual =
+                    calificacionesPasajeros[pasajero.id] ||
+                    crearEstadoInicialPasajeros([pasajero])[pasajero.id];
+
+                  return (
+                    <section key={pasajero.id} className="modal-puntuacion__tarjeta">
+                      <header className="modal-puntuacion__tarjeta-encabezado">
+                        {pasajero.avatar ? (
+                          <img
+                            src={pasajero.avatar}
+                            alt=""
+                            className="modal-puntuacion__avatar"
+                          />
+                        ) : (
+                          <span className="modal-puntuacion__avatar modal-puntuacion__avatar--placeholder">
+                            {pasajero.nombre?.[0]?.toUpperCase()}
+                          </span>
+                        )}
+                        <div>
+                          <h3 className="modal-puntuacion__tarjeta-titulo">
+                            {pasajero.nombre} {pasajero.apellido}
+                          </h3>
+                          <p className="modal-puntuacion__tarjeta-detalle">
+                            Puntualidad, amabilidad y experiencia general del viaje.
+                          </p>
+                        </div>
+                      </header>
+
+                      <div className="modal-puntuacion__campos">
+                        <label className="modal-puntuacion__campo">
+                          <span className="modal-puntuacion__campo-label">Puntualidad</span>
+                          {renderEstrellas(
+                            calificacionActual.puntualidad,
+                            (valor) =>
+                              manejarCambioPasajero(
+                                pasajero.id,
+                                "puntualidad",
+                                valor
+                              ),
+                            `Puntualidad de ${pasajero.nombre} ${pasajero.apellido}`
+                          )}
+                        </label>
+
+                        <label className="modal-puntuacion__campo">
+                          <span className="modal-puntuacion__campo-label">Amabilidad</span>
+                          {renderEstrellas(
+                            calificacionActual.amabilidad,
+                            (valor) =>
+                              manejarCambioPasajero(
+                                pasajero.id,
+                                "amabilidad",
+                                valor
+                              ),
+                            `Amabilidad de ${pasajero.nombre} ${pasajero.apellido}`
+                          )}
+                        </label>
+
+                        <label className="modal-puntuacion__campo">
+                          <span className="modal-puntuacion__campo-label">Puntuación general</span>
+                          {renderEstrellas(
+                            calificacionActual.general,
+                            (valor) =>
+                              manejarCambioPasajero(
+                                pasajero.id,
+                                "general",
+                                valor
+                              ),
+                            `Puntuación general de ${pasajero.nombre} ${pasajero.apellido}`
+                          )}
+                        </label>
+
+                        <label className="modal-puntuacion__campo">
+                          <span className="modal-puntuacion__campo-label">Comentario</span>
+                          <textarea
+                            className="modal-puntuacion__textarea"
+                            value={calificacionActual.comentario}
+                            onChange={(evento) =>
+                              manejarCambioPasajero(
+                                pasajero.id,
+                                "comentario",
+                                evento.target.value
+                              )
+                            }
+                            placeholder="Compartí detalles del viaje con esta persona"
+                          />
+                        </label>
+                      </div>
+                    </section>
+                  );
+                })
+              ) : (
+                <p className="modal-puntuacion__mensaje-vacio">
+                  No hay pasajeros aceptados para calificar en este viaje.
+                </p>
+              )}
+            </div>
+          ) : (
+            <section className="modal-puntuacion__tarjeta">
+              <header className="modal-puntuacion__tarjeta-encabezado">
+                <span className="modal-puntuacion__avatar modal-puntuacion__avatar--placeholder">
+                  {viaje.conductor?.[0]?.toUpperCase() || "?"}
+                </span>
+                <div>
+                  <h3 className="modal-puntuacion__tarjeta-titulo">
+                    {viaje.conductor || "Conductor"}
+                  </h3>
+                  <p className="modal-puntuacion__tarjeta-detalle">
+                    Valorá la puntualidad, la amabilidad y la conducción segura del viaje.
+                  </p>
+                </div>
+              </header>
+
+              <div className="modal-puntuacion__campos">
+                <label className="modal-puntuacion__campo">
+                  <span className="modal-puntuacion__campo-label">Puntualidad</span>
+                  {renderEstrellas(
+                    calificacionConductor.puntualidad,
+                    (valor) => manejarCambioConductor("puntualidad", valor),
+                    "Puntualidad del conductor"
+                  )}
+                </label>
+
+                <label className="modal-puntuacion__campo">
+                  <span className="modal-puntuacion__campo-label">Amabilidad</span>
+                  {renderEstrellas(
+                    calificacionConductor.amabilidad,
+                    (valor) => manejarCambioConductor("amabilidad", valor),
+                    "Amabilidad del conductor"
+                  )}
+                </label>
+
+                <label className="modal-puntuacion__campo">
+                  <span className="modal-puntuacion__campo-label">Conducción segura</span>
+                  {renderEstrellas(
+                    calificacionConductor.conduccionSegura,
+                    (valor) => manejarCambioConductor("conduccionSegura", valor),
+                    "Conducción segura del viaje"
+                  )}
+                </label>
+
+                <label className="modal-puntuacion__campo">
+                  <span className="modal-puntuacion__campo-label">Comentario</span>
+                  <textarea
+                    className="modal-puntuacion__textarea"
+                    value={calificacionConductor.comentario}
+                    onChange={(evento) =>
+                      manejarCambioConductor("comentario", evento.target.value)
+                    }
+                    placeholder="Comentá cómo fue el viaje con la persona que condujo"
+                  />
+                </label>
+              </div>
+            </section>
+          )}
+
+          <footer className="modal-puntuacion__acciones">
+            <button
+              type="button"
+              className="modal-puntuacion__boton modal-puntuacion__boton--secundario"
+              onClick={onCerrar}
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="modal-puntuacion__boton modal-puntuacion__boton--primario"
+            >
+              Guardar
+            </button>
+          </footer>
+        </form>
+      </div>
+      <div className="modal-puntuacion__fondo" onClick={onCerrar} aria-hidden="true" />
+    </div>
+  );
+}
+
+ModalPuntuacion.propTypes = {
+  abierto: PropTypes.bool,
+  tipo: PropTypes.oneOf(["propio", "ajeno"]),
+  viaje: PropTypes.shape({
+    id: PropTypes.string,
+    destino: PropTypes.string,
+    fecha: PropTypes.string,
+    conductor: PropTypes.string,
+    pasajeros: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        nombre: PropTypes.string,
+        apellido: PropTypes.string,
+        avatar: PropTypes.string,
+        estado: PropTypes.string,
+      })
+    ),
+  }),
+  onCerrar: PropTypes.func.isRequired,
+  onConfirmar: PropTypes.func.isRequired,
+};
+
+ModalPuntuacion.defaultProps = {
+  abierto: false,
+  tipo: undefined,
+  viaje: undefined,
+};
+
+export default ModalPuntuacion;

--- a/src/components/TarjetaMiViaje.jsx
+++ b/src/components/TarjetaMiViaje.jsx
@@ -16,7 +16,7 @@ const obtenerIniciales = (texto) => {
   return (partes[0][0] + partes[partes.length - 1][0]).toUpperCase();
 };
 
-function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros }) {
+function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros, onPuntuar }) {
   const esPropio = tipo === "propio";
   const avatarTexto = esPropio
     ? viaje.destino?.[0] || viaje.puntoEncuentro?.[0] || "?"
@@ -65,6 +65,9 @@ function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros }) {
     acciones.push({
       id: "puntuar",
       etiqueta: esPropio ? "Puntuar pasajeros" : "Puntuar conductor",
+      onClick: onPuntuar
+        ? () => onPuntuar(viaje, esPropio ? "propio" : "ajeno")
+        : undefined,
     });
   }
   if (!esPropio && estado === "pendiente") {
@@ -92,12 +95,10 @@ function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros }) {
         </div>
       </header>
 
-    {tipo === "ajeno" && (
+      {tipo === "ajeno" && (
         <div className="viaje-card__conductor">
           <div className="viaje-card__conductor-datos">
-            
             <div className="viaje-card__conductor-identidad">
-
               <span
                 className="viaje-card__label viaje-card__label-icon"
                 role="img"
@@ -105,7 +106,6 @@ function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros }) {
               >
                 <FaCar aria-hidden="true" />
               </span>
-
               <span className="viaje-card__conductor-nombre">
                 {viaje.conductor || "Por confirmar"}
               </span>
@@ -131,16 +131,16 @@ function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros }) {
           </div>
         </div>
       )}
-      
+
       {tipo === "ajeno" && (
-      <ul className="viaje-card__detalles">
-        {viaje.notas && (
-          <li className="viaje-card__nota">
-            <span className="viaje-card__label">Notas</span>
-            <span className="viaje-card__valor">{viaje.notas}</span>
-          </li>
-        )}
-      </ul>
+        <ul className="viaje-card__detalles">
+          {viaje.notas && (
+            <li className="viaje-card__nota">
+              <span className="viaje-card__label">Notas</span>
+              <span className="viaje-card__valor">{viaje.notas}</span>
+            </li>
+          )}
+        </ul>
       )}
       
 
@@ -180,10 +180,12 @@ TarjetaMiViaje.propTypes = {
   tipo: PropTypes.oneOf(["propio", "ajeno"]).isRequired,
   estado: PropTypes.oneOf(["pendiente", "finalizado"]).isRequired,
   onVerPasajeros: PropTypes.func,
+  onPuntuar: PropTypes.func,
 };
 
 TarjetaMiViaje.defaultProps = {
   onVerPasajeros: undefined,
+  onPuntuar: undefined,
 };
 
 export default TarjetaMiViaje;

--- a/src/pages/MisViajes.jsx
+++ b/src/pages/MisViajes.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import TarjetaMiViaje from "../components/TarjetaMiViaje";
 import ModalPasajeros from "../components/ModalPasajeros";
+import ModalPuntuacion from "../components/ModalPuntuacion";
 import "./MisViajes.css";
 
 const agruparPorEstado = (viajes) => {
@@ -16,11 +17,21 @@ const agruparPorEstado = (viajes) => {
   return { pendientes, finalizados };
 };
 
-function MisViajes({ viajesPropios = [], viajesAjenos = [], pestaniaInicial = "propios" }) {
+function MisViajes({
+  viajesPropios = [],
+  viajesAjenos = [],
+  pestaniaInicial = "propios",
+  onEnviarPuntuacion,
+}) {
   const [pestaniaActiva, setPestaniaActiva] = useState(pestaniaInicial);
   const [viajesPropiosEstado, setViajesPropiosEstado] = useState(viajesPropios);
   const [viajeSeleccionado, setViajeSeleccionado] = useState(null);
   const [modalPasajerosAbierto, setModalPasajerosAbierto] = useState(false);
+  const [modalPuntuacion, setModalPuntuacion] = useState({
+    abierto: false,
+    tipo: null,
+    viaje: null,
+  });
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -65,6 +76,22 @@ function MisViajes({ viajesPropios = [], viajesAjenos = [], pestaniaInicial = "p
   const handleCerrarModalPasajeros = () => {
     setModalPasajerosAbierto(false);
     setViajeSeleccionado(null);
+  };
+
+  const handleAbrirModalPuntuacion = (viaje, tipo) => {
+    setModalPuntuacion({ abierto: true, tipo, viaje });
+  };
+
+  const handleCerrarModalPuntuacion = () => {
+    setModalPuntuacion({ abierto: false, tipo: null, viaje: null });
+  };
+
+  const handleConfirmarPuntuacion = (datos) => {
+    if (typeof onEnviarPuntuacion === "function") {
+      onEnviarPuntuacion(datos);
+    }
+
+    handleCerrarModalPuntuacion();
   };
 
   const actualizarEstadoPasajero = (pasajeroId, nuevoEstado) => {
@@ -186,6 +213,7 @@ function MisViajes({ viajesPropios = [], viajesAjenos = [], pestaniaInicial = "p
                       ? () => handleVerPasajeros(viaje.id)
                       : undefined
                   }
+                  onPuntuar={handleAbrirModalPuntuacion}
                 />
               ))
             ) : (
@@ -208,6 +236,13 @@ function MisViajes({ viajesPropios = [], viajesAjenos = [], pestaniaInicial = "p
           viajeId={viajeSeleccionado.id}
         />
       )}
+      <ModalPuntuacion
+        abierto={modalPuntuacion.abierto}
+        tipo={modalPuntuacion.tipo}
+        viaje={modalPuntuacion.viaje}
+        onCerrar={handleCerrarModalPuntuacion}
+        onConfirmar={handleConfirmarPuntuacion}
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a scoring modal that supports rating passengers or a driver with star inputs and comments
- update MisViajes to manage the new rating modal state and provide callbacks to travel cards
- extend TarjetaMiViaje so completed trips expose the puntuar action

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a0920c70832fab8a2cb8e7d5d0b6