### PR TITLE
Agregar ícono de estado para viajes ajenos

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -260,6 +260,7 @@ const DATOS_DEMOSTRACION = {
       conductor: "Martín Fernández",
       asientoReservado: "Asiento 2 de 3",
       notas: "El viaje incluye peaje, llevar SUBE si quieren combinar.",
+      estadoSolicitud: "confirmada",
     },
     {
       id: "aj-2",
@@ -270,6 +271,7 @@ const DATOS_DEMOSTRACION = {
       conductor: "Valentina Ruiz",
       asientoReservado: "Asiento 1 de 4",
       notas: "Gran viaje, conducción muy segura.",
+      estadoSolicitud: "pendiente",
     },
     {
       id: "aj-3",
@@ -280,6 +282,7 @@ const DATOS_DEMOSTRACION = {
       conductor: "Ignacio Paredes",
       asientoReservado: "Asiento 3 de 3",
       notas: "Sale música tranquila durante el viaje.",
+      estadoSolicitud: "confirmada",
     },
   ],
   notificaciones: [

--- a/src/components/TarjetaMiViaje.css
+++ b/src/components/TarjetaMiViaje.css
@@ -8,6 +8,7 @@
   gap: 0.85rem;
   box-shadow: 0 10px 20px rgba(47, 42, 45, 0.04);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
 }
 
 .viaje-card:hover {
@@ -25,6 +26,43 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.viaje-card__header--con-estado {
+  padding-right: 2.5rem;
+}
+
+.viaje-card__estado {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  border: 2px solid transparent;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+  background-color: #fff;
+}
+
+.viaje-card__estado svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.viaje-card__estado--pendiente {
+  color: #d58b01;
+  border-color: rgba(213, 139, 1, 0.35);
+  background-color: rgba(247, 224, 182, 0.35);
+}
+
+.viaje-card__estado--aceptada {
+  color: #1f9d55;
+  border-color: rgba(31, 157, 85, 0.35);
+  background-color: rgba(192, 237, 211, 0.35);
 }
 
 .viaje-card__header-principal {

--- a/src/components/TarjetaMiViaje.jsx
+++ b/src/components/TarjetaMiViaje.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import "./TarjetaMiViaje.css";
 import { FaCar } from "react-icons/fa";
+import { FiCheck, FiClock } from "react-icons/fi";
 
 const formatFecha = (fechaISO, opciones) => {
   const fecha = new Date(fechaISO);
@@ -75,11 +76,41 @@ function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros, onPuntuar }) {
   }
   
 
+  const estadoSolicitudCrudo = (viaje.estadoSolicitud || viaje.estadoReserva || "")
+    .toString()
+    .toLowerCase();
+  const estadoSolicitud =
+    estadoSolicitudCrudo === "aceptada" || estadoSolicitudCrudo === "aceptado"
+      ? "aceptada"
+      : estadoSolicitudCrudo === "confirmada" || estadoSolicitudCrudo === "confirmado"
+      ? "aceptada"
+      : "pendiente";
+
+  const estadoSolicitudEtiqueta =
+    estadoSolicitud === "aceptada" ? "Solicitud aceptada" : "Solicitud pendiente";
+
   return (
     <article
       className={`viaje-card${estado === "finalizado" ? " viaje-card--finalizado" : ""}`}
     >
-      <header className="viaje-card__header">
+      <header
+        className={`viaje-card__header${
+          !esPropio ? " viaje-card__header--con-estado" : ""
+        }`}
+      >
+        {!esPropio && (
+          <div
+            className={`viaje-card__estado viaje-card__estado--${estadoSolicitud}`}
+            role="img"
+            aria-label={estadoSolicitudEtiqueta}
+          >
+            {estadoSolicitud === "aceptada" ? (
+              <FiCheck aria-hidden="true" />
+            ) : (
+              <FiClock aria-hidden="true" />
+            )}
+          </div>
+        )}
         <div className="viaje-card__header-principal">
           <div className="viaje-card__avatar" aria-hidden="true">
             {avatarTexto}
@@ -176,6 +207,8 @@ TarjetaMiViaje.propTypes = {
     notas: PropTypes.string,
     direccion: PropTypes.string,
     contactoConductor: PropTypes.string,
+    estadoSolicitud: PropTypes.string,
+    estadoReserva: PropTypes.string,
   }).isRequired,
   tipo: PropTypes.oneOf(["propio", "ajeno"]).isRequired,
   estado: PropTypes.oneOf(["pendiente", "finalizado"]).isRequired,


### PR DESCRIPTION
## Summary
- agregar un indicador visual del estado de la solicitud en las tarjetas de viajes ajenos
- ajustar los estilos de las tarjetas para ubicar el nuevo icono en la esquina superior derecha
- extender los datos de demostración con estados de solicitud para los viajes ajenos

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d9cfa36800832f941aff32d68514ba