### PR TITLE
Mostrar confirmación al cancelar solicitud en mis viajes

### DIFF
--- a/src/components/ModalConfirmacion.jsx
+++ b/src/components/ModalConfirmacion.jsx
@@ -1,4 +1,5 @@
 import { useId } from "react";
+import { createPortal } from "react-dom";
 import "./ModalConfirmacion.css";
 
 function ModalConfirmacion({
@@ -17,13 +18,17 @@ function ModalConfirmacion({
     return null;
   }
 
+  if (typeof document === "undefined") {
+    return null;
+  }
+
   const handleOverlayClick = (event) => {
     if (event.target === event.currentTarget) {
       onCancel?.();
     }
   };
 
-  return (
+  return createPortal(
     <div
       className="modal-confirmacion__overlay"
       role="dialog"
@@ -59,7 +64,8 @@ function ModalConfirmacion({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/src/components/TarjetaMiViaje.jsx
+++ b/src/components/TarjetaMiViaje.jsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
 import PropTypes from "prop-types";
 import "./TarjetaMiViaje.css";
 import { FaCar } from "react-icons/fa";
 import { FiCheck, FiClock } from "react-icons/fi";
-import ModalConfirmacion from "./ModalConfirmacion";
 
 const formatFecha = (fechaISO, opciones) => {
   const fecha = new Date(fechaISO);
@@ -28,20 +26,6 @@ function TarjetaMiViaje({
   onCancelar,
 }) {
   const esPropio = tipo === "propio";
-  const [mostrarModalCancelacion, setMostrarModalCancelacion] = useState(false);
-
-  const abrirModalCancelacion = () => {
-    setMostrarModalCancelacion(true);
-  };
-
-  const cerrarModalCancelacion = () => {
-    setMostrarModalCancelacion(false);
-  };
-
-  const confirmarCancelacion = () => {
-    setMostrarModalCancelacion(false);
-    onCancelar?.(viaje);
-  };
   const avatarTexto = esPropio
     ? viaje.destino?.[0] || viaje.puntoEncuentro?.[0] || "?"
     : obtenerIniciales(viaje.conductor);
@@ -98,7 +82,7 @@ function TarjetaMiViaje({
     acciones.push({
       id: "cancelar-asistencia",
       etiqueta: "Cancelar",
-      onClick: abrirModalCancelacion,
+      onClick: () => onCancelar?.(viaje),
     });
   }
   
@@ -217,16 +201,6 @@ function TarjetaMiViaje({
           ))}
         </div>
       )}
-
-      <ModalConfirmacion
-        isOpen={mostrarModalCancelacion}
-        titulo="Cancelar solicitud"
-        descripcion="¿Estás seguro de que deseas cancelar la solicitud del viaje?"
-        confirmText="Sí, cancelar"
-        cancelText="No, volver"
-        onConfirm={confirmarCancelacion}
-        onCancel={cerrarModalCancelacion}
-      />
     </article>
   );
 }

--- a/src/components/TarjetaMiViaje.jsx
+++ b/src/components/TarjetaMiViaje.jsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import PropTypes from "prop-types";
 import "./TarjetaMiViaje.css";
 import { FaCar } from "react-icons/fa";
 import { FiCheck, FiClock } from "react-icons/fi";
+import ModalConfirmacion from "./ModalConfirmacion";
 
 const formatFecha = (fechaISO, opciones) => {
   const fecha = new Date(fechaISO);
@@ -17,8 +19,29 @@ const obtenerIniciales = (texto) => {
   return (partes[0][0] + partes[partes.length - 1][0]).toUpperCase();
 };
 
-function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros, onPuntuar }) {
+function TarjetaMiViaje({
+  viaje,
+  tipo,
+  estado,
+  onVerPasajeros,
+  onPuntuar,
+  onCancelar,
+}) {
   const esPropio = tipo === "propio";
+  const [mostrarModalCancelacion, setMostrarModalCancelacion] = useState(false);
+
+  const abrirModalCancelacion = () => {
+    setMostrarModalCancelacion(true);
+  };
+
+  const cerrarModalCancelacion = () => {
+    setMostrarModalCancelacion(false);
+  };
+
+  const confirmarCancelacion = () => {
+    setMostrarModalCancelacion(false);
+    onCancelar?.(viaje);
+  };
   const avatarTexto = esPropio
     ? viaje.destino?.[0] || viaje.puntoEncuentro?.[0] || "?"
     : obtenerIniciales(viaje.conductor);
@@ -72,7 +95,11 @@ function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros, onPuntuar }) {
     });
   }
   if (!esPropio && estado === "pendiente") {
-    acciones.push({ id: "cancelar-asistencia", etiqueta: "Cancelar" });
+    acciones.push({
+      id: "cancelar-asistencia",
+      etiqueta: "Cancelar",
+      onClick: abrirModalCancelacion,
+    });
   }
   
 
@@ -190,6 +217,16 @@ function TarjetaMiViaje({ viaje, tipo, estado, onVerPasajeros, onPuntuar }) {
           ))}
         </div>
       )}
+
+      <ModalConfirmacion
+        isOpen={mostrarModalCancelacion}
+        titulo="Cancelar solicitud"
+        descripcion="¿Estás seguro de que deseas cancelar la solicitud del viaje?"
+        confirmText="Sí, cancelar"
+        cancelText="No, volver"
+        onConfirm={confirmarCancelacion}
+        onCancel={cerrarModalCancelacion}
+      />
     </article>
   );
 }
@@ -214,11 +251,13 @@ TarjetaMiViaje.propTypes = {
   estado: PropTypes.oneOf(["pendiente", "finalizado"]).isRequired,
   onVerPasajeros: PropTypes.func,
   onPuntuar: PropTypes.func,
+  onCancelar: PropTypes.func,
 };
 
 TarjetaMiViaje.defaultProps = {
   onVerPasajeros: undefined,
   onPuntuar: undefined,
+  onCancelar: undefined,
 };
 
 export default TarjetaMiViaje;

--- a/src/pages/MisViajes.jsx
+++ b/src/pages/MisViajes.jsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import TarjetaMiViaje from "../components/TarjetaMiViaje";
 import ModalPasajeros from "../components/ModalPasajeros";
 import ModalPuntuacion from "../components/ModalPuntuacion";
+import ModalConfirmacion from "../components/ModalConfirmacion";
 import "./MisViajes.css";
 
 const agruparPorEstado = (viajes) => {
@@ -22,6 +23,7 @@ function MisViajes({
   viajesAjenos = [],
   pestaniaInicial = "propios",
   onEnviarPuntuacion,
+  onCancelarSolicitud,
 }) {
   const [pestaniaActiva, setPestaniaActiva] = useState(pestaniaInicial);
   const [viajesPropiosEstado, setViajesPropiosEstado] = useState(viajesPropios);
@@ -32,6 +34,7 @@ function MisViajes({
     tipo: null,
     viaje: null,
   });
+  const [viajeACancelar, setViajeACancelar] = useState(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -92,6 +95,22 @@ function MisViajes({
     }
 
     handleCerrarModalPuntuacion();
+  };
+
+  const handleAbrirModalCancelacion = (viaje) => {
+    setViajeACancelar(viaje);
+  };
+
+  const handleCerrarModalCancelacion = () => {
+    setViajeACancelar(null);
+  };
+
+  const handleConfirmarCancelacion = () => {
+    if (viajeACancelar && typeof onCancelarSolicitud === "function") {
+      onCancelarSolicitud(viajeACancelar);
+    }
+
+    setViajeACancelar(null);
   };
 
   const actualizarEstadoPasajero = (pasajeroId, nuevoEstado) => {
@@ -188,6 +207,7 @@ function MisViajes({
                       ? () => handleVerPasajeros(viaje.id)
                       : undefined
                   }
+                  onCancelar={() => handleAbrirModalCancelacion(viaje)}
                 />
               ))
             ) : (
@@ -242,6 +262,15 @@ function MisViajes({
         viaje={modalPuntuacion.viaje}
         onCerrar={handleCerrarModalPuntuacion}
         onConfirmar={handleConfirmarPuntuacion}
+      />
+      <ModalConfirmacion
+        isOpen={Boolean(viajeACancelar)}
+        titulo="Cancelar solicitud"
+        descripcion="¿Estás seguro de que deseas cancelar la solicitud del viaje?"
+        confirmText="Sí, cancelar"
+        cancelText="No, volver"
+        onConfirm={handleConfirmarCancelacion}
+        onCancel={handleCerrarModalCancelacion}
       />
     </main>
   );


### PR DESCRIPTION
## Summary
- integrar ModalConfirmacion en TarjetaMiViaje para confirmar la cancelación de solicitudes
- agregar estado local para controlar la apertura del modal y llamar a un callback opcional al confirmar

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9d3a2f164832f95272268872734af