### PR TITLE
Add confirmation modal workflow to notification page

### DIFF
--- a/src/pages/NotificationPage.jsx
+++ b/src/pages/NotificationPage.jsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { FiBell } from "react-icons/fi";
 import Notification from "../components/Notification";
 import RequestNotification from "../components/RequestNotification";
+import ModalConfirmacion from "../components/ModalConfirmacion";
 
 export default function NotificationPage({
   solicitudes = [],
@@ -9,6 +10,40 @@ export default function NotificationPage({
   onAcceptSolicitud,
   onRejectSolicitud,
 }) {
+  const [accionPendiente, setAccionPendiente] = useState(null);
+
+  const abrirModalAccion = (solicitud, accion) => {
+    setAccionPendiente({ solicitud, accion });
+  };
+
+  const cerrarModalAccion = () => {
+    setAccionPendiente(null);
+  };
+
+  const confirmarAccion = () => {
+    if (!accionPendiente) return;
+
+    const { solicitud, accion } = accionPendiente;
+
+    if (accion === "accept") {
+      onAcceptSolicitud?.(solicitud);
+    } else if (accion === "reject") {
+      onRejectSolicitud?.(solicitud);
+    }
+
+    cerrarModalAccion();
+  };
+
+  const esAceptar = accionPendiente?.accion === "accept";
+  const solicitudSeleccionada = accionPendiente?.solicitud;
+  const tituloModal = esAceptar ? "Aceptar solicitud" : "Rechazar solicitud";
+  const descripcionModal = solicitudSeleccionada
+    ? esAceptar
+      ? `¿Deseás aceptar la solicitud "${solicitudSeleccionada.titulo}"?`
+      : `¿Deseás rechazar la solicitud "${solicitudSeleccionada.titulo}"?`
+    : "";
+  const confirmText = esAceptar ? "Sí, aceptar" : "Sí, rechazar";
+
   return (
     <section className="notificaciones-page">
       <ul className="notificaciones-lista">
@@ -20,8 +55,8 @@ export default function NotificationPage({
             descripcion={solicitud.descripcion}
             icono={solicitud.icono}
             destacada={solicitud.destacada}
-            onAccept={() => onAcceptSolicitud?.(solicitud)}
-            onReject={() => onRejectSolicitud?.(solicitud)}
+            onAccept={() => abrirModalAccion(solicitud, "accept")}
+            onReject={() => abrirModalAccion(solicitud, "reject")}
           />
         ))}
 
@@ -42,6 +77,15 @@ export default function NotificationPage({
           <li className="notificaciones-vacias">No tenés notificaciones nuevas.</li>
         )}
       </ul>
+      <ModalConfirmacion
+        isOpen={Boolean(accionPendiente)}
+        titulo={tituloModal}
+        descripcion={descripcionModal}
+        confirmText={confirmText}
+        cancelText="No, volver"
+        onConfirm={confirmarAccion}
+        onCancel={cerrarModalAccion}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- track the selected solicitud and pending action in NotificationPage
- display ModalConfirmacion to confirm accepting or rejecting solicitudes before invoking callbacks

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e01a17d4832fa8fc637c4438bbf3