### PR TITLE
Add passenger data and profile navigation to request notifications

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -315,6 +315,28 @@ const DATOS_DEMOSTRACION = {
       descripcion:
         "Valentina solicitó unirse a tu viaje hacia USAL Pilar el 7 de Octubre a las 18:00 hrs.",
       icono: FiUsers,
+      viajeId: "prop-1",
+      pasajero: {
+        id: "pas-987",
+        nombre: "Valentina",
+        apellido: "Ruiz",
+        avatar: "https://i.pravatar.cc/120?img=45",
+        barrio: "Haras Santa María",
+        lote: "1275",
+        telefono: "+54 9 11 4899-1188",
+        resenas: [
+          {
+            id: "pas-987-r1",
+            autor: "Laura S.",
+            comentario: "Excelente compañera de viaje, siempre avisa si se retrasa.",
+          },
+          {
+            id: "pas-987-r2",
+            autor: "Ignacio P.",
+            comentario: "Muy buena onda y respeta los horarios.",
+          },
+        ],
+      },
     },
   ],
 };

--- a/src/components/RequestNotification.css
+++ b/src/components/RequestNotification.css
@@ -1,26 +1,24 @@
-.notificacion-card__acciones {
-  margin-top: 0.75rem;
-  display: flex;
-  gap: 0.5rem;
+
+.notificacion-card__icono--avatar {
+  padding: 0;
+  background: transparent;
 }
 
-.request-notificacion__pasajero {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.75rem;
+.notificacion-card__icono--avatar .request-notificacion__avatar-boton {
+  width: 44px;
+  height: 44px;
 }
 
 .request-notificacion__avatar-boton {
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
+  border-radius: 12px;
   border: none;
   padding: 0;
   overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  height: 100%;
   background: #fce2df;
   color: #ff5841;
   font-weight: 600;
@@ -45,6 +43,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  height: 100%;
   background: #fce2df;
   color: #ff5841;
 }
@@ -53,6 +53,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
+  margin-bottom: 0.65rem;
 }
 
 .request-notificacion__nombre {
@@ -63,6 +64,12 @@
 .request-notificacion__detalle {
   font-size: 0.85rem;
   color: #6b7280;
+}
+
+.notificacion-card__acciones {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
 }
 
 .notificacion-card__btn {

--- a/src/components/RequestNotification.css
+++ b/src/components/RequestNotification.css
@@ -4,6 +4,67 @@
   gap: 0.5rem;
 }
 
+.request-notificacion__pasajero {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.request-notificacion__avatar-boton {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  border: none;
+  padding: 0;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #fce2df;
+  color: #ff5841;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.request-notificacion__avatar-boton:hover,
+.request-notificacion__avatar-boton:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 3px rgba(197, 54, 120, 0.15);
+}
+
+.request-notificacion__avatar {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.request-notificacion__avatar--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #fce2df;
+  color: #ff5841;
+}
+
+.request-notificacion__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.request-notificacion__nombre {
+  font-weight: 600;
+  color: #27272a;
+}
+
+.request-notificacion__detalle {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
 .notificacion-card__btn {
   flex: 1;
   padding: 0.5rem 0.75rem;

--- a/src/components/RequestNotification.jsx
+++ b/src/components/RequestNotification.jsx
@@ -40,6 +40,36 @@ const RequestNotification = ({
     .filter(Boolean)
     .join(" · ");
 
+  const iconoContenido = pasajero ? (
+    <button
+      type="button"
+      className="request-notificacion__avatar-boton"
+      onClick={manejarVerPerfil}
+      aria-label={`Ver perfil de ${pasajero.nombre} ${pasajero.apellido}`}
+    >
+      {pasajero.avatar ? (
+        <img
+          className="request-notificacion__avatar"
+          src={pasajero.avatar}
+          alt=""
+        />
+      ) : (
+        <span className="request-notificacion__avatar request-notificacion__avatar--placeholder">
+          {obtenerIniciales(pasajero.nombre, pasajero.apellido)}
+        </span>
+      )}
+    </button>
+  ) : (
+    <Icono />
+  );
+
+  const iconoClase = [
+    "notificacion-card__icono",
+    pasajero ? "notificacion-card__icono--avatar" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <Tag
       className={`notificacion-card notificacion-card--con-acciones${
@@ -47,38 +77,18 @@ const RequestNotification = ({
       } ${className}`.trim()}
       role={Tag === "li" ? undefined : "listitem"}
     >
-      <span className="notificacion-card__icono" aria-hidden="true">
-        <Icono />
+      <span className={iconoClase} {...(pasajero ? {} : { "aria-hidden": "true" })}>
+        {iconoContenido}
       </span>
       <div className="notificacion-card__contenido">
         {pasajero && (
-          <div className="request-notificacion__pasajero">
-            <button
-              type="button"
-              className="request-notificacion__avatar-boton"
-              onClick={manejarVerPerfil}
-              aria-label={`Ver perfil de ${pasajero.nombre} ${pasajero.apellido}`}
-            >
-              {pasajero.avatar ? (
-                <img
-                  className="request-notificacion__avatar"
-                  src={pasajero.avatar}
-                  alt=""
-                />
-              ) : (
-                <span className="request-notificacion__avatar request-notificacion__avatar--placeholder">
-                  {obtenerIniciales(pasajero.nombre, pasajero.apellido)}
-                </span>
-              )}
-            </button>
-            <div className="request-notificacion__info">
-              <span className="request-notificacion__nombre">
-                {pasajero.nombre} {pasajero.apellido}
-              </span>
-              {detalleUbicacion && (
-                <span className="request-notificacion__detalle">{detalleUbicacion}</span>
-              )}
-            </div>
+          <div className="request-notificacion__info">
+            <span className="request-notificacion__nombre">
+              {pasajero.nombre} {pasajero.apellido}
+            </span>
+            {detalleUbicacion && (
+              <span className="request-notificacion__detalle">{detalleUbicacion}</span>
+            )}
           </div>
         )}
 

--- a/src/components/RequestNotification.jsx
+++ b/src/components/RequestNotification.jsx
@@ -3,20 +3,43 @@ import PropTypes from "prop-types";
 import { FiBell } from "react-icons/fi";
 import "./RequestNotification.css";
 
+const obtenerIniciales = (nombre = "", apellido = "") => {
+  const inicialNombre = nombre.trim()[0];
+  const inicialApellido = apellido.trim()[0];
+
+  return `${inicialNombre || ""}${inicialApellido || ""}`.toUpperCase() || "?";
+};
+
 /**
  * Tarjeta de notificación con botones de acción.
- * Extiende el estilo de NotificationCard agregando Aceptar/Rechazar.
+ * Extiende el estilo de NotificationCard agregando Aceptar/Rechazar
+ * y acceso directo al perfil del pasajero que realiza la solicitud.
  */
 const RequestNotification = ({
   titulo,
   descripcion,
   icono: Icono = FiBell,
   destacada = false,
+  pasajero,
+  onVerPerfil,
   onAccept,
   onReject,
   className = "",
   as: Tag = "li",
 }) => {
+  const manejarVerPerfil = () => {
+    if (pasajero && onVerPerfil) {
+      onVerPerfil(pasajero);
+    }
+  };
+
+  const detalleUbicacion = [
+    pasajero?.barrio?.trim(),
+    pasajero?.lote ? `Lote ${pasajero.lote}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
   return (
     <Tag
       className={`notificacion-card notificacion-card--con-acciones${
@@ -28,6 +51,37 @@ const RequestNotification = ({
         <Icono />
       </span>
       <div className="notificacion-card__contenido">
+        {pasajero && (
+          <div className="request-notificacion__pasajero">
+            <button
+              type="button"
+              className="request-notificacion__avatar-boton"
+              onClick={manejarVerPerfil}
+              aria-label={`Ver perfil de ${pasajero.nombre} ${pasajero.apellido}`}
+            >
+              {pasajero.avatar ? (
+                <img
+                  className="request-notificacion__avatar"
+                  src={pasajero.avatar}
+                  alt=""
+                />
+              ) : (
+                <span className="request-notificacion__avatar request-notificacion__avatar--placeholder">
+                  {obtenerIniciales(pasajero.nombre, pasajero.apellido)}
+                </span>
+              )}
+            </button>
+            <div className="request-notificacion__info">
+              <span className="request-notificacion__nombre">
+                {pasajero.nombre} {pasajero.apellido}
+              </span>
+              {detalleUbicacion && (
+                <span className="request-notificacion__detalle">{detalleUbicacion}</span>
+              )}
+            </div>
+          </div>
+        )}
+
         <h3 className="notificacion-card__titulo">{titulo}</h3>
         <p className="notificacion-card__texto">{descripcion}</p>
 
@@ -57,6 +111,23 @@ RequestNotification.propTypes = {
   descripcion: PropTypes.string.isRequired,
   icono: PropTypes.elementType,
   destacada: PropTypes.bool,
+  pasajero: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    nombre: PropTypes.string.isRequired,
+    apellido: PropTypes.string.isRequired,
+    avatar: PropTypes.string,
+    barrio: PropTypes.string,
+    lote: PropTypes.string,
+    telefono: PropTypes.string,
+    resenas: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+        autor: PropTypes.string,
+        comentario: PropTypes.string,
+      })
+    ),
+  }).isRequired,
+  onVerPerfil: PropTypes.func,
   onAccept: PropTypes.func,
   onReject: PropTypes.func,
   className: PropTypes.string,

--- a/src/pages/NotificationPage.jsx
+++ b/src/pages/NotificationPage.jsx
@@ -1,14 +1,39 @@
 import React from "react";
+import PropTypes from "prop-types";
+import { useLocation, useNavigate } from "react-router-dom";
 import { FiBell } from "react-icons/fi";
 import Notification from "../components/Notification";
 import RequestNotification from "../components/RequestNotification";
 
 export default function NotificationPage({
-  solicitudes = [],
-  notificaciones = [],
+  solicitudes,
+  notificaciones,
   onAcceptSolicitud,
   onRejectSolicitud,
 }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleVerPerfilSolicitud = (pasajero, solicitud) => {
+    if (!pasajero?.id) {
+      return;
+    }
+
+    navigate(`/perfil-pasajero/${pasajero.id}`, {
+      state: {
+        pasajero,
+        from: {
+          pathname: location.pathname,
+          state: {
+            solicitudId: solicitud?.id,
+            viajeId: solicitud?.viajeId,
+            reabrirModal: true,
+          },
+        },
+      },
+    });
+  };
+
   return (
     <section className="notificaciones-page">
       <ul className="notificaciones-lista">
@@ -20,6 +45,10 @@ export default function NotificationPage({
             descripcion={solicitud.descripcion}
             icono={solicitud.icono}
             destacada={solicitud.destacada}
+            pasajero={solicitud.pasajero}
+            onVerPerfil={(pasajeroSeleccionado) =>
+              handleVerPerfilSolicitud(pasajeroSeleccionado, solicitud)
+            }
             onAccept={() => onAcceptSolicitud?.(solicitud)}
             onReject={() => onRejectSolicitud?.(solicitud)}
           />
@@ -45,3 +74,51 @@ export default function NotificationPage({
     </section>
   );
 }
+
+NotificationPage.propTypes = {
+  solicitudes: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      titulo: PropTypes.string.isRequired,
+      descripcion: PropTypes.string.isRequired,
+      icono: PropTypes.elementType,
+      destacada: PropTypes.bool,
+      viajeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      pasajero: PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+        nombre: PropTypes.string.isRequired,
+        apellido: PropTypes.string.isRequired,
+        avatar: PropTypes.string,
+        barrio: PropTypes.string,
+        lote: PropTypes.string,
+        telefono: PropTypes.string,
+        resenas: PropTypes.arrayOf(
+          PropTypes.shape({
+            id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+            autor: PropTypes.string,
+            comentario: PropTypes.string,
+          })
+        ),
+      }).isRequired,
+    })
+  ),
+  notificaciones: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      titulo: PropTypes.string.isRequired,
+      descripcion: PropTypes.string.isRequired,
+      icono: PropTypes.elementType,
+      destacada: PropTypes.bool,
+      onClick: PropTypes.func,
+    })
+  ),
+  onAcceptSolicitud: PropTypes.func,
+  onRejectSolicitud: PropTypes.func,
+};
+
+NotificationPage.defaultProps = {
+  solicitudes: [],
+  notificaciones: [],
+  onAcceptSolicitud: undefined,
+  onRejectSolicitud: undefined,
+};


### PR DESCRIPTION
## Summary
- include passenger metadata in demo solicitudes so notification handlers can assemble navigation state
- add a navigation handler in NotificationPage and pass passenger data through RequestNotification
- render an interactive avatar in request notifications with refreshed styles and stricter prop types

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e4e12240832f8974d8e29dd83aac